### PR TITLE
Fixed Wazuh API validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 - Added post-install validations for the Wazuh manager and Filebeat. ([#3059](https://github.com/wazuh/wazuh-packages/pull/3059))
 
+### Fixed
+
+- Fixed Wazuh API validation ([#29](https://github.com/wazuh/wazuh-installation-assistant/pull/29))
+
 ## [4.9.0]
 
 - https://github.com/wazuh/wazuh-packages/releases/tag/v4.9.0

--- a/install_functions/manager.sh
+++ b/install_functions/manager.sh
@@ -47,7 +47,7 @@ function manager_checkService() {
     eval "TOKEN=$(curl -k -s -X POST -u "wazuh-wui:wazuh-wui" https://127.0.0.1:55000/security/user/authenticate/run_as?raw=true -d '{"user_name":"wzread"}' -H "content-type:application/json")"
     wm_error=$(curl -k -s -X GET "https://127.0.0.1:55000/agents/outdated?pretty=true" -H "Authorization: Bearer ${TOKEN}")
 
-    if  [[ ${wm_error,,} = '"error": 0' ]]; then
+    if  [[ ${wm_error,,} =~ '"error": 0' ]]; then
         common_logger "Wazuh API connection successful"
     else
         common_logger -e "Wazuh API connection Error. $wm_error"


### PR DESCRIPTION
## Description

Closes: https://github.com/wazuh/wazuh-installation-assistant/issues/28
The aim of this PR is to fix the Wazuh API validation incoporated in https://github.com/wazuh/wazuh-packages/pull/3059.

> [!TIP]
> Instead comparing the Wazuh API output with the exact string `error: 0`, the fix consist in using the substring operator. This means that the Wazuh API validation will be passed if the Wazuh API output **contains** the string `error: 0`.

The fix has been debugged in order to check the correct behavior:
```console
20/08/2024 11:07:42 INFO: Checking Wazuh API connection
+ [[ {
   "data": {
      "affected_items": [],
      "total_affected_items": 0,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "no agent information was returned",
   "error": 0
} =~ "error": 0 ]]
+ common_logger 'Wazuh API connection successful'
```

<details><summary>Installation log - AIO installation</summary>

```console
root@ip-172-31-85-12:/home/ubuntu# bash wazuh-install.sh -a -v
20/08/2024 10:10:39 DEBUG: Checking root permissions.
20/08/2024 10:10:39 DEBUG: Checking sudo package.
20/08/2024 10:10:39 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.1
20/08/2024 10:10:39 INFO: Verbose logging redirected to /var/log/wazuh-install.log
20/08/2024 10:10:39 DEBUG: APT package manager will be used.
20/08/2024 10:10:39 DEBUG: Checking system distribution.
20/08/2024 10:10:39 DEBUG: Detected distribution name: ubuntu
20/08/2024 10:10:39 DEBUG: Detected distribution version: 22
20/08/2024 10:10:39 DEBUG: Installing check dependencies.
Hit:1 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy InRelease
Get:2 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-updates InRelease [128 kB]
Hit:3 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-backports InRelease
Get:4 http://security.ubuntu.com/ubuntu jammy-security InRelease [129 kB]
Fetched 257 kB in 0s (529 kB/s)
Reading package lists...
20/08/2024 10:10:48 DEBUG: Checking Wazuh installation.
20/08/2024 10:10:49 DEBUG: Checking system architecture.
20/08/2024 10:10:49 INFO: Verifying that your system meets the recommended minimum hardware requirements.
20/08/2024 10:10:49 DEBUG: CPU cores detected: 4
20/08/2024 10:10:49 DEBUG: Free RAM memory detected: 7847
20/08/2024 10:10:49 DEBUG: Installing check dependencies.
Hit:1 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:3 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-backports InRelease
Hit:4 http://security.ubuntu.com/ubuntu jammy-security InRelease
Reading package lists...
20/08/2024 10:10:53 INFO: Wazuh web interface port will be 443.
20/08/2024 10:10:53 DEBUG: Checking ports availability.
Hit:1 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:3 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-backports InRelease
Hit:4 http://security.ubuntu.com/ubuntu jammy-security InRelease
Reading package lists...
20/08/2024 10:10:55 DEBUG: Installing prerequisites dependencies.
20/08/2024 10:10:58 DEBUG: Checking curl tool version.
20/08/2024 10:10:58 DEBUG: Adding the Wazuh repository.
gpg: keyring '/usr/share/keyrings/wazuh.gpg' created
gpg: key 96B3EE5F29111145: public key "Wazuh.com (Wazuh Signing Key) <support@wazuh.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main
Hit:1 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:3 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-backports InRelease
Get:4 https://packages.wazuh.com/4.x/apt stable InRelease [17.3 kB]
Hit:5 http://security.ubuntu.com/ubuntu jammy-security InRelease
Get:6 https://packages.wazuh.com/4.x/apt stable/main amd64 Packages [42.1 kB]
Fetched 59.4 kB in 0s (189 kB/s)
Reading package lists...
20/08/2024 10:11:00 INFO: Wazuh repository added.
20/08/2024 10:11:00 INFO: --- Configuration files ---
20/08/2024 10:11:00 INFO: Generating configuration files.
20/08/2024 10:11:00 DEBUG: Creating Wazuh certificates.
20/08/2024 10:11:00 DEBUG: Reading configuration file.
20/08/2024 10:11:00 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 10:11:00 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 10:11:00 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 10:11:00 INFO: Generating the root certificate.
20/08/2024 10:11:00 INFO: Generating Admin certificates.
20/08/2024 10:11:00 DEBUG: Generating Admin private key.
20/08/2024 10:11:01 DEBUG: Converting Admin private key to PKCS8 format.
20/08/2024 10:11:01 DEBUG: Generating Admin CSR.
20/08/2024 10:11:01 DEBUG: Creating Admin certificate.
20/08/2024 10:11:01 INFO: Generating Wazuh indexer certificates.
20/08/2024 10:11:01 DEBUG: Creating the certificates for wazuh-indexer indexer node.
20/08/2024 10:11:01 DEBUG: Generating certificate configuration.
20/08/2024 10:11:01 DEBUG: Creating the Wazuh indexer tmp key pair.
20/08/2024 10:11:01 DEBUG: Creating the Wazuh indexer certificates.
20/08/2024 10:11:01 INFO: Generating Filebeat certificates.
20/08/2024 10:11:01 DEBUG: Generating the certificates for wazuh-server server node.
20/08/2024 10:11:01 DEBUG: Generating certificate configuration.
20/08/2024 10:11:01 DEBUG: Creating the Wazuh server tmp key pair.
20/08/2024 10:11:01 DEBUG: Creating the Wazuh server certificates.
20/08/2024 10:11:01 INFO: Generating Wazuh dashboard certificates.
20/08/2024 10:11:01 DEBUG: Generating certificate configuration.
20/08/2024 10:11:01 DEBUG: Creating the Wazuh dashboard tmp key pair.
20/08/2024 10:11:01 DEBUG: Creating the Wazuh dashboard certificates.
20/08/2024 10:11:01 DEBUG: Cleaning certificate files.
20/08/2024 10:11:01 DEBUG: Generating password file.
20/08/2024 10:11:01 DEBUG: Generating random passwords.
20/08/2024 10:11:01 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
20/08/2024 10:11:01 DEBUG: Extracting Wazuh configuration.
20/08/2024 10:11:01 DEBUG: Reading configuration file.
20/08/2024 10:11:01 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 10:11:01 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 10:11:01 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 10:11:01 INFO: --- Wazuh indexer ---
20/08/2024 10:11:01 INFO: Starting Wazuh indexer installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-indexer 0 upgraded, 1 newly installed, 0 to remove and 203 not upgraded. Need to get 0 B/756 MB of archives. After this operation, 1050 MB of additional disk space will be used. Selecting previously unselected package NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.19.0-1025-aws NEEDRESTART-KEXP: 5.19.0-1025-aws NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: acpid.service NEEDRESTART-SVC: chrony.service NEEDRESTART-SVC: cron.service NEEDRESTART-SVC: dbus.service NEEDRESTART-SVC: getty@tty1.service NEEDRESTART-SVC: irqbalance.service NEEDRESTART-SVC: multipathd.service NEEDRESTART-SVC: networkd-dispatcher.service NEEDRESTART-SVC: packagekit.service NEEDRESTART-SVC: polkit.service NEEDRESTART-SVC: rsyslog.service NEEDRESTART-SVC: serial-getty@ttyS0.service NEEDRESTART-SVC: snapd.service NEEDRESTART-SVC: ssh.service NEEDRESTART-SVC: systemd-journald.service NEEDRESTART-SVC: systemd-logind.service NEEDRESTART-SVC: systemd-networkd.service NEEDRESTART-SVC: systemd-resolved.service NEEDRESTART-SVC: systemd-udevd.service NEEDRESTART-SVC: unattended-upgrades.service NEEDRESTART-SVC: user@1000.service
20/08/2024 10:11:52 DEBUG: Checking Wazuh installation.
20/08/2024 10:11:53 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 10:11:53 INFO: Wazuh indexer installation finished.
20/08/2024 10:11:53 DEBUG: Configuring Wazuh indexer.
20/08/2024 10:11:53 DEBUG: Copying Wazuh indexer certificates.
20/08/2024 10:11:53 INFO: Wazuh indexer post-install configuration finished.
20/08/2024 10:11:53 INFO: Starting service wazuh-indexer.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.
20/08/2024 10:12:04 INFO: wazuh-indexer service started.
20/08/2024 10:12:04 INFO: Initializing Wazuh indexer cluster security settings.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success
20/08/2024 10:12:16 INFO: Wazuh indexer cluster security configuration initialized.
20/08/2024 10:12:16 INFO: Wazuh indexer cluster initialized.
20/08/2024 10:12:16 INFO: --- Wazuh server ---
20/08/2024 10:12:16 INFO: Starting the Wazuh manager installation.
Reading package lists... Building dependency tree... Reading state information... Suggested packages: expect The following NEW packages will be installed: wazuh-manager 0 upgraded, 1 newly installed, 0 to remove and 203 not upgraded. Need to get 0 B/310 MB of archives. After this operation, 911 MB of additional disk space will be used. Selecting pre NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.19.0-1025-aws NEEDRESTART-KEXP: 5.19.0-1025-aws NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: acpid.service NEEDRESTART-SVC: chrony.service NEEDRESTART-SVC: cron.service NEEDRESTART-SVC: dbus.service NEEDRESTART-SVC: getty@tty1.service NEEDRESTART-SVC: irqbalance.service NEEDRESTART-SVC: multipathd.service NEEDRESTART-SVC: networkd-dispatcher.service NEEDRESTART-SVC: packagekit.service NEEDRESTART-SVC: polkit.service NEEDRESTART-SVC: rsyslog.service NEEDRESTART-SVC: serial-getty@ttyS0.service NEEDRESTART-SVC: snapd.service NEEDRESTART-SVC: ssh.service NEEDRESTART-SVC: systemd-journald.service NEEDRESTART-SVC: systemd-logind.service NEEDRESTART-SVC: systemd-networkd.service NEEDRESTART-SVC: systemd-resolved.service NEEDRESTART-SVC: systemd-udevd.service NEEDRESTART-SVC: unattended-upgrades.service NEEDRESTART-SVC: user@1000.service
20/08/2024 10:12:58 DEBUG: Checking Wazuh installation.
20/08/2024 10:12:58 DEBUG: There are Wazuh remaining files.
20/08/2024 10:12:58 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 10:12:59 INFO: Wazuh manager installation finished.
20/08/2024 10:12:59 DEBUG: Configuring Wazuh manager.
20/08/2024 10:12:59 DEBUG: Setting provisional Wazuh indexer password.
20/08/2024 10:12:59 INFO: Wazuh manager vulnerability detection configuration finished.
20/08/2024 10:12:59 INFO: Starting service wazuh-manager.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.
20/08/2024 10:13:13 INFO: wazuh-manager service started.
20/08/2024 10:13:13 INFO: Checking Wazuh API connection
20/08/2024 10:13:13 INFO: Wazuh API connection successful
20/08/2024 10:13:13 INFO: Starting Filebeat installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: filebeat 0 upgraded, 1 newly installed, 0 to remove and 203 not upgraded. Need to get 22.1 MB of archives. After this operation, 73.6 MB of additional disk space will be used. Get:1 https://packages.wazuh.com/4.x/apt stable/main amd64 filebeat amd64 7.10.2 [22.1 MB] Fetched 22.1 MB in 0s (63.5 MB/s) Selecting previously unselected package NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.19.0-1025-aws NEEDRESTART-KEXP: 5.19.0-1025-aws NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: acpid.service NEEDRESTART-SVC: chrony.service NEEDRESTART-SVC: cron.service NEEDRESTART-SVC: dbus.service NEEDRESTART-SVC: getty@tty1.service NEEDRESTART-SVC: irqbalance.service NEEDRESTART-SVC: multipathd.service NEEDRESTART-SVC: networkd-dispatcher.service NEEDRESTART-SVC: packagekit.service NEEDRESTART-SVC: polkit.service NEEDRESTART-SVC: rsyslog.service NEEDRESTART-SVC: serial-getty@ttyS0.service NEEDRESTART-SVC: snapd.service NEEDRESTART-SVC: ssh.service NEEDRESTART-SVC: systemd-journald.service NEEDRESTART-SVC: systemd-logind.service NEEDRESTART-SVC: systemd-networkd.service NEEDRESTART-SVC: systemd-resolved.service NEEDRESTART-SVC: systemd-udevd.service NEEDRESTART-SVC: unattended-upgrades.service NEEDRESTART-SVC: user@1000.service
20/08/2024 10:13:24 DEBUG: Checking Wazuh installation.
20/08/2024 10:13:25 DEBUG: There are Wazuh remaining files.
20/08/2024 10:13:25 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 10:13:26 DEBUG: There are Filebeat remaining files.
20/08/2024 10:13:26 INFO: Filebeat installation finished.
20/08/2024 10:13:26 DEBUG: Configuring Filebeat.
20/08/2024 10:13:26 DEBUG: Filebeat template was download successfully.
wazuh/
wazuh/_meta/
wazuh/_meta/docs.asciidoc
wazuh/_meta/fields.yml
wazuh/_meta/config.yml
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/module.yml
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
20/08/2024 10:13:26 DEBUG: Filebeat module was downloaded successfully.
20/08/2024 10:13:26 DEBUG: Copying Filebeat certificates.
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
20/08/2024 10:13:27 INFO: Filebeat post-install configuration finished.
20/08/2024 10:13:27 INFO: Starting service filebeat.
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.
20/08/2024 10:13:28 INFO: filebeat service started.
20/08/2024 10:13:28 INFO: Checking Filebeat connection
20/08/2024 10:13:28 INFO: Filebeat connection successful
20/08/2024 10:13:28 INFO: --- Wazuh dashboard ---
20/08/2024 10:13:28 INFO: Starting Wazuh dashboard installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-dashboard 0 upgraded, 1 newly installed, 0 to remove and 203 not upgraded. Need to get 186 MB of archives. After this operation, 998 MB of additional disk space will be used. Get:1 https://packages.wazuh.com/4.x/apt stable/main amd64 wazuh-dashboard amd64 4.8.1-1 [186 MB] Fetched 186 MB in 4s (52.7 MB/s) Selecting previously unselec NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.19.0-1025-aws NEEDRESTART-KEXP: 5.19.0-1025-aws NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: acpid.service NEEDRESTART-SVC: chrony.service NEEDRESTART-SVC: cron.service NEEDRESTART-SVC: dbus.service NEEDRESTART-SVC: getty@tty1.service NEEDRESTART-SVC: irqbalance.service NEEDRESTART-SVC: multipathd.service NEEDRESTART-SVC: networkd-dispatcher.service NEEDRESTART-SVC: packagekit.service NEEDRESTART-SVC: polkit.service NEEDRESTART-SVC: rsyslog.service NEEDRESTART-SVC: serial-getty@ttyS0.service NEEDRESTART-SVC: snapd.service NEEDRESTART-SVC: ssh.service NEEDRESTART-SVC: systemd-journald.service NEEDRESTART-SVC: systemd-logind.service NEEDRESTART-SVC: systemd-networkd.service NEEDRESTART-SVC: systemd-resolved.service NEEDRESTART-SVC: systemd-udevd.service NEEDRESTART-SVC: unattended-upgrades.service NEEDRESTART-SVC: user@1000.service
20/08/2024 10:16:04 DEBUG: Checking Wazuh installation.
20/08/2024 10:16:04 DEBUG: There are Wazuh remaining files.
20/08/2024 10:16:04 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 10:16:05 DEBUG: There are Filebeat remaining files.
20/08/2024 10:16:05 DEBUG: There are Wazuh dashboard remaining files.
20/08/2024 10:16:05 INFO: Wazuh dashboard installation finished.
20/08/2024 10:16:05 DEBUG: Configuring Wazuh dashboard.
20/08/2024 10:16:05 DEBUG: Copying Wazuh dashboard certificates.
20/08/2024 10:16:05 DEBUG: Wazuh dashboard certificate setup finished.
20/08/2024 10:16:05 INFO: Wazuh dashboard post-install configuration finished.
20/08/2024 10:16:05 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
20/08/2024 10:16:05 INFO: wazuh-dashboard service started.
20/08/2024 10:16:05 DEBUG: Setting Wazuh indexer cluster passwords.
20/08/2024 10:16:05 DEBUG: Checking Wazuh installation.
20/08/2024 10:16:06 DEBUG: There are Wazuh remaining files.
20/08/2024 10:16:06 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 10:16:07 DEBUG: There are Filebeat remaining files.
20/08/2024 10:16:07 DEBUG: There are Wazuh dashboard remaining files.
20/08/2024 10:16:07 INFO: Updating the internal users.
20/08/2024 10:16:07 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
20/08/2024 10:16:10 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
20/08/2024 10:16:10 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
20/08/2024 10:16:10 DEBUG: The internal users have been updated before changing the passwords.
20/08/2024 10:16:10 DEBUG: Generating password hashes.
20/08/2024 10:16:14 DEBUG: Password hashes generated.
20/08/2024 10:16:14 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
20/08/2024 10:16:17 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
Successfully updated the keystore
Successfully updated the keystore
20/08/2024 10:16:17 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
20/08/2024 10:16:17 DEBUG: Restarting filebeat service...
20/08/2024 10:16:17 DEBUG: filebeat started.
20/08/2024 10:16:17 DEBUG: Restarting wazuh-manager service...
20/08/2024 10:16:33 DEBUG: wazuh-manager started.
20/08/2024 10:16:34 DEBUG: Restarting wazuh-dashboard service...
20/08/2024 10:16:34 DEBUG: wazuh-dashboard started.
20/08/2024 10:16:34 DEBUG: Running security admin tool.
20/08/2024 10:16:34 DEBUG: Loading new passwords changes.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /home/ubuntu
Force type: internalusers
Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
Done with success
20/08/2024 10:16:36 DEBUG: Passwords changed.
20/08/2024 10:16:36 DEBUG: Changing API passwords.
20/08/2024 10:16:44 INFO: Initializing Wazuh dashboard web application.
20/08/2024 10:16:44 INFO: Wazuh dashboard web application not yet initialized. Waiting...
20/08/2024 10:17:00 INFO: Wazuh dashboard web application not yet initialized. Waiting...
20/08/2024 10:17:15 INFO: Wazuh dashboard web application initialized.
20/08/2024 10:17:15 INFO: --- Summary ---
20/08/2024 10:17:15 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: Z*6rCVMO5QBu3bN1tptTI7JOMxaQzV95
20/08/2024 10:17:15 DEBUG: Restoring Wazuh repository.
20/08/2024 10:17:15 INFO: Installation finished.

```
</details>