### PR TITLE
Added Test installation assistant workflows

### DIFF
--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -1,0 +1,58 @@
+run-name: Test installation assistant - System ${{ inputs.SYSTEM }} - Launched by @${{ github.actor }}
+name: Test installation assistant 
+
+on:
+  pull_request:
+    paths:
+      - 'cert_tool/**'
+      - 'common_functions/**'
+      - 'config/**'
+      - 'install_functions/**'
+      - 'passwords_tool/**'
+      - 'tests/**'
+  workflow_dispatch:
+    inputs:
+      REPOSITORY:
+        description: 'Repository environment'
+        required: true
+        default: 'pre-release'
+        type: choice
+        options:
+          - staging
+          - pre-release
+      SYSTEM:
+        description: 'Operating System'
+        required: true
+        default: 'CentOS 8'
+        type: choice
+        options:
+          - CentOS 7
+          - CentOS 8
+          - Amazon Linux 2
+          - Ubuntu 16
+          - Ubuntu 18
+          - Ubuntu 20
+          - Ubuntu 22
+          - RHEL7
+          - RHEL8
+      DEBUG:
+        description: 'Debug mode'
+        required: true
+        default: false
+        type: boolean
+      DESTROY:
+        description: 'Destroy instances after run'
+        required: true
+        default: true
+        type: boolean
+
+env:
+  LABEL: ubuntu-latest
+
+jobs:
+  initialize-environment:
+    runs-on: $LABEL
+
+    steps:
+    - name: Set up Git
+      uses: actions/checkout@v3

--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -20,6 +20,10 @@ on:
         options:
           - staging
           - pre-release
+      AUTOMATION_REFERENCE:
+        description: 'wazuh-automation reference'
+        required: true
+        default: 'v4.10.0'
       SYSTEM:
         description: 'Operating System'
         required: true

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -20,6 +20,10 @@ on:
         options:
           - staging
           - pre-release
+      AUTOMATION_REFERENCE:
+        description: 'wazuh-automation reference'
+        required: true
+        default: 'v4.10.0'
       DEBUG:
         description: 'Debug mode'
         required: true

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -1,0 +1,43 @@
+run-name: (Distributed) Test installation assistant - Launched by @${{ github.actor }}
+name: (Distributed) Test installation assistant
+
+on:
+  pull_request:
+    paths:
+      - 'cert_tool/**'
+      - 'common_functions/**'
+      - 'config/**'
+      - 'install_functions/**'
+      - 'passwords_tool/**'
+      - 'tests/**'
+  workflow_dispatch:
+    inputs:
+      REPOSITORY:
+        description: 'Repository environment'
+        required: true
+        default: 'pre-release'
+        type: choice
+        options:
+          - staging
+          - pre-release
+      DEBUG:
+        description: 'Debug mode'
+        required: true
+        default: false
+        type: boolean
+      DESTROY:
+        description: 'Destroy instances after run'
+        required: true
+        default: true
+        type: boolean
+
+env:
+  LABEL: ubuntu-latest
+
+jobs:
+  initialize-environment:
+    runs-on: $LABEL
+
+    steps:
+    - name: Set up Git
+      uses: actions/checkout@v3

--- a/.github/workflows/Test_installation_assistant_tier.yml
+++ b/.github/workflows/Test_installation_assistant_tier.yml
@@ -1,0 +1,80 @@
+run-name: (Tier) Test installation assistant - Launched by @${{ github.actor }}
+name: (Tier) Test installation assistant
+
+on:
+  workflow_dispatch:
+    inputs:
+      REPOSITORY:
+        description: 'Repository environment'
+        required: true
+        default: 'pre-release'
+        type: choice
+        options:
+          - staging
+          - pre-release
+      CentOS_7:
+        description: 'CentOS 7'
+        required: true
+        default: false
+        type: boolean
+      CentOS_8:
+        description: 'CentOS 8'
+        required: true
+        default: true
+        type: boolean
+      Amazon_Linux_2:
+        description: 'Amazon Linux 2'
+        required: true
+        default: false
+        type: boolean
+      Ubuntu_16:
+        description: 'Ubuntu 16'
+        required: true
+        default: false
+        type: boolean
+      Ubuntu_18:
+        description: 'Ubuntu 18'
+        required: true
+        default: false
+        type: boolean
+      Ubuntu_20:
+        description: 'Ubuntu 20'
+        required: true
+        default: false
+        type: boolean
+      Ubuntu_22:
+        description: 'Ubuntu 22'
+        required: true
+        default: false
+        type: boolean
+      RHEL_7:
+        description: 'RHEL 7'
+        required: true
+        default: false
+        type: boolean
+      RHEL_8:
+        description: 'RHEL 8'
+        required: true
+        default: false
+        type: boolean
+      DEBUG:
+        description: 'Debug mode'
+        required: true
+        default: false
+        type: boolean
+      DESTROY:
+        description: 'Destroy instances after run'
+        required: true
+        default: true
+        type: boolean
+
+env:
+  LABEL: ubuntu-latest
+
+jobs:
+  launch-tests:
+    runs-on: $LABEL
+
+    steps:
+    - name: Set up Git
+      uses: actions/checkout@v3

--- a/.github/workflows/Test_installation_assistant_tier.yml
+++ b/.github/workflows/Test_installation_assistant_tier.yml
@@ -12,6 +12,10 @@ on:
         options:
           - staging
           - pre-release
+      AUTOMATION_REFERENCE:
+        description: 'wazuh-automation reference'
+        required: true
+        default: 'v4.10.0'
       CentOS_7:
         description: 'CentOS 7'
         required: true


### PR DESCRIPTION
## Description

Related: https://github.com/wazuh/wazuh-installation-assistant/issues/20
The aim of this PR is to add the header of the new workflows `Test_installation_assistant.yml`, `Test_installation_assistant_tier.yml` and `Test_installation_assistant_distributed.yml`. These workflows represent the old `Test_unattended` Jenkins pipelines.

It is necessary to add this header to the `main` branch in order to test the workflow and finish its development.