### PR TITLE
Added gitignore file to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+wazuh-install.sh
+wazuh-passwords-tool.sh
+wazuh-certs-tool.sh
+*.pem
+*.ova
+*.ovf
+*.deb
+*.rpm
+*.zip
+*.tar.gz
+*.pkg
+*.msi
+*.log
+*.key

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 wazuh-install.sh
 wazuh-passwords-tool.sh
 wazuh-certs-tool.sh
+config.yml
+wazuh-install-files.tar
+wazuh-install-files/
+wazuh-offline.tar.gz
 *.pem
 *.ova
 *.ovf

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ config.yml
 wazuh-install-files.tar
 wazuh-install-files/
 wazuh-offline.tar.gz
+wazuh-offline/
 *.pem
 *.ova
 *.ovf


### PR DESCRIPTION
Related: https://github.com/wazuh/wazuh-installation-assistant/issues/41
## Description
The aim of this PR is to add the `.gitignore` file to the repository in order to not track some files when developing.