### PR TITLE
Fixed manager check in distributed deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed Wazuh API validation ([#29](https://github.com/wazuh/wazuh-installation-assistant/pull/29))
 - Fixed token variable empty in Wazuh manager check ([#45](https://github.com/wazuh/wazuh-installation-assistant/pull/45))
+- Fixed manager check in distributed deploymentn ([#52](https://github.com/wazuh/wazuh-installation-assistant/pull/52))
 
 ## [4.9.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed Wazuh API validation ([#29](https://github.com/wazuh/wazuh-installation-assistant/pull/29))
 - Fixed token variable empty in Wazuh manager check ([#45](https://github.com/wazuh/wazuh-installation-assistant/pull/45))
-- Fixed manager check in distributed deploymentn ([#52](https://github.com/wazuh/wazuh-installation-assistant/pull/52))
+- Fixed manager check in distributed deployment ([#52](https://github.com/wazuh/wazuh-installation-assistant/pull/52))
 
 ## [4.9.1]
 


### PR DESCRIPTION
## Description

Closes: https://github.com/wazuh/wazuh-installation-assistant/issues/51
The aim of this PR is to fix the Wazuh manager service check distributed deployments. The fix consists in changing the credentials when getting the API token in the Wazuh manager worker nodes. These nodes are installed after the master node, and the master node changes the API passwords, so the worker node must use the changed password.

Apart from the fix, a new validation has been added to the loop to check that the API token is not empty. The new validation controls if the API generates a cluster error, which is produced when the master and worker nodes are installed simultaneously. This scenario is not contemplated in the documentation, as the manager nodes are installed sequentially. However, with this improvement, the Wazuh manager installation will not fail if the nodes are installed simultaneously, for example, when using an Ansible playbook.

## Testing

Testing is in: https://github.com/wazuh/wazuh-installation-assistant/issues/51#issuecomment-2343384743 