### PR TITLE
Check available space before the installation with the installation assistant

### DIFF
--- a/install_functions/installMain.sh
+++ b/install_functions/installMain.sh
@@ -263,22 +263,27 @@ function main() {
     fi
 
     if [ -n "${AIO}" ]; then
+        installCommon_checkDiskSpace "AIO"
         rm -f "${tar_file}"
         checks_ports "${wazuh_aio_ports[@]}"
         installCommon_installPrerequisites "AIO"
     fi
 
     if [ -n "${indexer}" ]; then
+        installCommon_checkDiskSpace "wazuh-indexer"
         checks_ports "${wazuh_indexer_ports[@]}"
         installCommon_installPrerequisites "indexer"
     fi
 
     if [ -n "${wazuh}" ]; then
+        installCommon_checkDiskSpace "wazuh-manager"
+        installCommon_checkDiskSpace "fliebeat"
         checks_ports "${wazuh_manager_ports[@]}"
         installCommon_installPrerequisites "wazuh"
     fi
 
     if [ -n "${dashboard}" ]; then
+        installCommon_checkDiskSpace "wazuh-dashboard"
         checks_ports "${wazuh_dashboard_port}"
         installCommon_installPrerequisites "dashboard"
     fi


### PR DESCRIPTION
# Description

Previously, when Wazuh was installed using the installation assistant and there wasn't enough space to complete the installation, an attempt was made to remove the components, but this failed, leaving them unremovable https://github.com/wazuh/wazuh-installation-assistant/issues/5#issuecomment-2203608347.

To address this, it was decided that before any installation, the available space in each directory used by the Wazuh installation should be checked. This is necessary because if only the disk space is checked, we may not be verifying all the required space, as the user may have different partitions configured https://github.com/wazuh/wazuh-installation-assistant/issues/5#issuecomment-2263779764.

After investigating which directories Wazuh uses and how much space it occupies after installation https://github.com/wazuh/wazuh-installation-assistant/issues/5#issuecomment-2338493580, a function has been implemented that checks the available space for each partition and compares it to the required space to ensure a successful installation.

## Tests

Several tests have been conducted to verify the proper functioning of this solution. These include verifying that the installation proceeds correctly when sufficient space is available, as well as ensuring that, with a partition created for a specific directory, the components are not installed due to insufficient space.

Them can be found here:

- https://github.com/wazuh/wazuh-installation-assistant/issues/5#issuecomment-2346532665

## Related issue

- #5 