### PR TITLE
Add build installation assistant header

### DIFF
--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -1,0 +1,10 @@
+run-name: Build Installation Assistant - Wazuh installation assistant branch ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }} - Launched by @${{ github.actor }}
+name: Build Installation Assistant
+
+on:
+  workflow_dispatch:
+    inputs:
+      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
+        description: 'Branch or tag of the wazuh-installation-assistant repository where the workflow will be triggered'
+        required: true
+        default: '5.0.0'


### PR DESCRIPTION
# Description

The aim of this PR is to include the `builder_installation_assistant.yml` GHA workflow header in the `main` branch to continue working on it.

## Related issue

- #55 