### PR TITLE
Create GHA workflow to build Wazuh Installation Assistant files

### DIFF
--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -1,11 +1,11 @@
-run-name: Build Installation Assistant - Wazuh installation assistant branch ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }} - Launched by @${{ github.actor }}
+run-name: Build Installation Assistant - Wazuh installation assistant branch ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }} - Launched by @${{ github.actor }}
 name: Build Installation Assistant
 
 on:
   workflow_dispatch:
     inputs:
-      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
-        description: 'Branch or tag of the wazuh-installation-assistant repository where the workflow will be triggered'
+      WAZUH_INSTALLATION_ASSISTANT_VERSION:
+        description: 'Branch of the wazuh-installation-assistant repository where the workflow will be triggered'
         required: true
         default: '4.10.0'
       DEVELOPMENT:
@@ -15,6 +15,7 @@ on:
 
 env:
   S3_BUCKET: "packages-dev.internal.wazuh.com"
+  S3_REPOSITORY_PATH: "development/wazuh/4.x/secondary/installation-assistant/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}"
   BUILDER_PATH: "builder.sh"
   WAZUH_INSTALL_NAME: "wazuh-install"
   WAZUH_CERT_TOOL_NAME: "wazuh-certs-tool"
@@ -35,7 +36,7 @@ jobs:
       - name: Checkout wazuh-installation-assistant repository
         uses: actions/checkout@v2
         with:
-          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
       
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v3
@@ -49,23 +50,28 @@ jobs:
           sed -i 's|${{ env.WAZUH_CERT_TOOL_NAME }}.sh|${{ env.WAZUH_CERT_TOOL_NAME }}-${{ github.sha }}.sh|g' "${{ env.BUILDER_PATH }}"
           sed -i 's|${{ env.WAZUH_PASSWORD_TOOL_NAME }}.sh|${{ env.WAZUH_PASSWORD_TOOL_NAME }}-${{ github.sha }}.sh|g' "${{ env.BUILDER_PATH }}"
 
-      - name: Build Installation Assistant files
-        run: |
-          command="bash builder.sh -i -c -p"
-          if [ "${{ inputs.DEVELOPMENT }}" == true ]; then
-            command="$command -d"
-          fi
-          $command
-      
+      - name: Build development Installation Assistant packages
+        if: ${{ ! inputs.DEVELOPMENT }}
+        run: bash builder.sh -i -c -p
+
+      - name: Build stage Installation Assistant packages
+        if: ${{ inputs.DEVELOPMENT }}
+        run: bash builder.sh -i -c -p -d
+
       - name: Prepare files
         run: |
-          mkdir -p ${{ github.workspace }}/wazuh-installation-assistant-files
-          mv ${{ env.WAZUH_INSTALL_NAME }}*.sh ${{ github.workspace }}/wazuh-installation-assistant-files
-          mv ${{ env.WAZUH_CERT_TOOL_NAME }}*.sh ${{ github.workspace }}/wazuh-installation-assistant-files
-          mv ${{ env.WAZUH_PASSWORD_TOOL_NAME }}*.sh ${{ github.workspace }}/wazuh-installation-assistant-files
+          mkdir -p ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
+          mv ${{ env.WAZUH_INSTALL_NAME }}*.sh ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
+          mv ${{ env.WAZUH_CERT_TOOL_NAME }}*.sh ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
+          mv ${{ env.WAZUH_PASSWORD_TOOL_NAME }}*.sh ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
      
+      - name: Upload files to S3
+        run: |
+          aws s3 cp ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }} --acl public-read --recursive
+
       - name: Create artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: wazuh-installation-assistant-files
-          path: ${{ github.workspace }}/wazuh-installation-assistant-files
+          name: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
+          path: ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -24,7 +24,7 @@ on:
 
 env:
   WAZUH_INSTALLATION_ASSISTANT_VERSION: ${{ github.ref_name }}
-  S3_BUCKET: "packages-dev.internal.wazuh.com"
+  S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
   S3_REPOSITORY_PATH: "development/wazuh/4.x/secondary/installation-assistant"
   BUILDER_PATH: "builder.sh"
   WAZUH_INSTALL_NAME: "wazuh-install"

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -1,21 +1,31 @@
-run-name: Build Installation Assistant - Wazuh installation assistant branch ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }} - Launched by @${{ github.actor }}
+run-name: Build Installation Assistant ${{ inputs.id }} - Wazuh installation assistant branch ${{ github.ref_name }} - Launched by @${{ github.actor }}
 name: Build Installation Assistant
 
 on:
   workflow_dispatch:
     inputs:
-      WAZUH_INSTALLATION_ASSISTANT_VERSION:
-        description: 'Branch of the wazuh-installation-assistant repository where the workflow will be triggered'
-        required: true
-        default: '4.10.0'
-      DEVELOPMENT:
-        description: 'Build installation assistant in development mode'
+      is_stage:
+        description: "Is stage?"
         type: boolean
+        default: false
+      id:
+        description: "ID used to identify the workflow uniquely."
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      is_stage:
+        description: "Is stage?"
+        type: boolean
+        default: false
+      id:
+        type: string
         required: false
 
 env:
+  WAZUH_INSTALLATION_ASSISTANT_VERSION: ${{ github.ref_name }}
   S3_BUCKET: "packages-dev.internal.wazuh.com"
-  S3_REPOSITORY_PATH: "development/wazuh/4.x/secondary/installation-assistant/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}"
+  S3_REPOSITORY_PATH: "development/wazuh/4.x/secondary/installation-assistant"
   BUILDER_PATH: "builder.sh"
   WAZUH_INSTALL_NAME: "wazuh-install"
   WAZUH_CERT_TOOL_NAME: "wazuh-certs-tool"
@@ -36,42 +46,45 @@ jobs:
       - name: Checkout wazuh-installation-assistant repository
         uses: actions/checkout@v2
         with:
-          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
+          ref: ${{ env.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
       
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           aws-region: us-east-1
-      - name: Change files name in builder.sh in development mode
-        if: ${{ inputs.DEVELOPMENT }}
+      
+      - name: Get short sha and wazuh version
         run: |
-          sed -i 's|${{ env.WAZUH_INSTALL_NAME }}.sh|${{ env.WAZUH_INSTALL_NAME }}-${{ github.sha }}.sh|g' "${{ env.BUILDER_PATH }}"
-          sed -i 's|${{ env.WAZUH_CERT_TOOL_NAME }}.sh|${{ env.WAZUH_CERT_TOOL_NAME }}-${{ github.sha }}.sh|g' "${{ env.BUILDER_PATH }}"
-          sed -i 's|${{ env.WAZUH_PASSWORD_TOOL_NAME }}.sh|${{ env.WAZUH_PASSWORD_TOOL_NAME }}-${{ github.sha }}.sh|g' "${{ env.BUILDER_PATH }}"
+          COMMIT_SHORT_SHA=$(git rev-parse --short ${{ github.sha }})
+          WAZUH_VERSION=$(grep -oP '(?<=readonly wazuh_version=").*(?=")' ${{github.workspace}}/install_functions/installVariables.sh)
+          echo "WAZUH_VERSION=$WAZUH_VERSION" >> $GITHUB_ENV
+          echo "COMMIT_SHORT_SHA=$COMMIT_SHORT_SHA" >> $GITHUB_ENV
 
-      - name: Build development Installation Assistant packages
-        if: ${{ ! inputs.DEVELOPMENT }}
+      - name: Change files name for stage build
+        if: ${{ inputs.is_stage == false }}
+        run: |
+          sed -i 's|${{ env.WAZUH_INSTALL_NAME }}.sh|${{ env.WAZUH_INSTALL_NAME }}-${{ env.COMMIT_SHORT_SHA }}.sh|g' "${{ env.BUILDER_PATH }}"
+          sed -i 's|${{ env.WAZUH_CERT_TOOL_NAME }}.sh|${{ env.WAZUH_CERT_TOOL_NAME }}-${{ env.COMMIT_SHORT_SHA }}.sh|g' "${{ env.BUILDER_PATH }}"
+          sed -i 's|${{ env.WAZUH_PASSWORD_TOOL_NAME }}.sh|${{ env.WAZUH_PASSWORD_TOOL_NAME }}-${{ env.COMMIT_SHORT_SHA }}.sh|g' "${{ env.BUILDER_PATH }}"
+
+      - name: Build Installation Assistant packages
         run: bash builder.sh -i -c -p
-
-      - name: Build stage Installation Assistant packages
-        if: ${{ inputs.DEVELOPMENT }}
-        run: bash builder.sh -i -c -p -d
 
       - name: Prepare files
         run: |
-          mkdir -p ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
-          mv ${{ env.WAZUH_INSTALL_NAME }}*.sh ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
-          mv ${{ env.WAZUH_CERT_TOOL_NAME }}*.sh ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
-          mv ${{ env.WAZUH_PASSWORD_TOOL_NAME }}*.sh ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
+          mkdir -p ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
+          mv ${{ env.WAZUH_INSTALL_NAME }}*.sh ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
+          mv ${{ env.WAZUH_CERT_TOOL_NAME }}*.sh ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
+          mv ${{ env.WAZUH_PASSWORD_TOOL_NAME }}*.sh ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
      
       - name: Upload files to S3
         run: |
-          aws s3 cp ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }} --recursive
+          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }} --recursive
 
       - name: Create artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
-          path: ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
+          name: ${{ env.WAZUH_VERSION }}
+          path: ${{ github.workspace }}/${{ env.WAZUH_VERSION }}

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -23,7 +23,6 @@ on:
         required: false
 
 env:
-  WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.ref_name }}
   S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
   S3_REPOSITORY_PATH: "development/wazuh/4.x/secondary/installation-assistant"
   BUILDER_PATH: "builder.sh"
@@ -45,8 +44,6 @@ jobs:
 
       - name: Checkout wazuh-installation-assistant repository
         uses: actions/checkout@v2
-        with:
-          ref: ${{ env.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
       
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v3
@@ -72,7 +69,6 @@ jobs:
         run: bash builder.sh -i -c -p
 
       - name: Prepare files
-        id: prepare_files
         run: |
           mkdir -p ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
           mv ${{ env.WAZUH_INSTALL_NAME }}*.sh ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
@@ -82,10 +78,3 @@ jobs:
       - name: Upload files to S3
         run: |
           aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }} --recursive
-
-      - name: Create artifact
-        if: always() && steps.prepare_files.outcome == 'success'
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.WAZUH_VERSION }}
-          path: ${{ github.workspace }}/${{ env.WAZUH_VERSION }}

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -1,4 +1,4 @@
-run-name: Build Installation Assistant ${{ inputs.id }} - Wazuh installation assistant branch ${{ github.ref_name }} - Launched by @${{ github.actor }}
+run-name: Build Installation Assistant ${{ inputs.id }} - Branch ${{ github.ref_name }} - Launched by @${{ github.actor }}
 name: Build Installation Assistant
 
 on:
@@ -72,6 +72,7 @@ jobs:
         run: bash builder.sh -i -c -p
 
       - name: Prepare files
+        id: prepare_files
         run: |
           mkdir -p ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
           mv ${{ env.WAZUH_INSTALL_NAME }}*.sh ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
@@ -83,7 +84,7 @@ jobs:
           aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }} --recursive
 
       - name: Create artifact
-        if: always()
+        if: always() && steps.prepare_files.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.WAZUH_VERSION }}

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -67,7 +67,7 @@ jobs:
      
       - name: Upload files to S3
         run: |
-          aws s3 cp ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }} --acl public-read --recursive
+          aws s3 cp ${{ github.workspace }}/${{ inputs.WAZUH_INSTALLATION_ASSISTANT_VERSION }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }} --recursive
 
       - name: Create artifact
         if: always()

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -1,0 +1,71 @@
+run-name: Build Installation Assistant - Wazuh installation assistant branch ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }} - Launched by @${{ github.actor }}
+name: Build Installation Assistant
+
+on:
+  workflow_dispatch:
+    inputs:
+      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
+        description: 'Branch or tag of the wazuh-installation-assistant repository where the workflow will be triggered'
+        required: true
+        default: '4.10.0'
+      DEVELOPMENT:
+        description: 'Build installation assistant in development mode'
+        type: boolean
+        required: false
+
+env:
+  S3_BUCKET: "packages-dev.internal.wazuh.com"
+  BUILDER_PATH: "builder.sh"
+  WAZUH_INSTALL_NAME: "wazuh-install"
+  WAZUH_CERT_TOOL_NAME: "wazuh-certs-tool"
+  WAZUH_PASSWORD_TOOL_NAME: "wazuh-passwords-tool"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  Build_Installation_Assistant:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: View parameters
+        run: echo "${{ toJson(inputs) }}"
+
+      - name: Checkout wazuh-installation-assistant repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+      
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: us-east-1
+      - name: Change files name in builder.sh in development mode
+        if: ${{ inputs.DEVELOPMENT }}
+        run: |
+          sed -i 's|${{ env.WAZUH_INSTALL_NAME }}.sh|${{ env.WAZUH_INSTALL_NAME }}-${{ github.sha }}.sh|g' "${{ env.BUILDER_PATH }}"
+          sed -i 's|${{ env.WAZUH_CERT_TOOL_NAME }}.sh|${{ env.WAZUH_CERT_TOOL_NAME }}-${{ github.sha }}.sh|g' "${{ env.BUILDER_PATH }}"
+          sed -i 's|${{ env.WAZUH_PASSWORD_TOOL_NAME }}.sh|${{ env.WAZUH_PASSWORD_TOOL_NAME }}-${{ github.sha }}.sh|g' "${{ env.BUILDER_PATH }}"
+
+      - name: Build Installation Assistant files
+        run: |
+          command="bash builder.sh -i -c -p"
+          if [ "${{ inputs.DEVELOPMENT }}" == true ]; then
+            command="$command -d"
+          fi
+          $command
+      
+      - name: Prepare files
+        run: |
+          mkdir -p ${{ github.workspace }}/wazuh-installation-assistant-files
+          mv ${{ env.WAZUH_INSTALL_NAME }}*.sh ${{ github.workspace }}/wazuh-installation-assistant-files
+          mv ${{ env.WAZUH_CERT_TOOL_NAME }}*.sh ${{ github.workspace }}/wazuh-installation-assistant-files
+          mv ${{ env.WAZUH_PASSWORD_TOOL_NAME }}*.sh ${{ github.workspace }}/wazuh-installation-assistant-files
+     
+      - name: Create artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wazuh-installation-assistant-files
+          path: ${{ github.workspace }}/wazuh-installation-assistant-files

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -23,7 +23,7 @@ on:
         required: false
 
 env:
-  WAZUH_INSTALLATION_ASSISTANT_VERSION: ${{ github.ref_name }}
+  WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.ref_name }}
   S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
   S3_REPOSITORY_PATH: "development/wazuh/4.x/secondary/installation-assistant"
   BUILDER_PATH: "builder.sh"
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout wazuh-installation-assistant repository
         uses: actions/checkout@v2
         with:
-          ref: ${{ env.WAZUH_INSTALLATION_ASSISTANT_VERSION }}
+          ref: ${{ env.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
       
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Migrate the build Installation Assistant files jenkins workflow to GHA ([#77](https://github.com/wazuh/wazuh-installation-assistant/pull/77))
+- Create GHA workflow to build Wazuh Installation Assistant files. ([#77](https://github.com/wazuh/wazuh-installation-assistant/pull/77))
 - Installation assistant distributed test rework and migration. ([#60](https://github.com/wazuh/wazuh-installation-assistant/pull/60))
 - Installation assistant test and tier workflow migration ([#46](https://github.com/wazuh/wazuh-installation-assistant/pull/46/))
 - Added post-install validations for the Wazuh manager and Filebeat. ([#3059](https://github.com/wazuh/wazuh-packages/pull/3059))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Migrate the build Installation Assistant files jenkins workflow to GHA ([#77](https://github.com/wazuh/wazuh-installation-assistant/pull/77))
 - Installation assistant distributed test rework and migration. ([#60](https://github.com/wazuh/wazuh-installation-assistant/pull/60))
 - Installation assistant test and tier workflow migration ([#46](https://github.com/wazuh/wazuh-installation-assistant/pull/46/))
 - Added post-install validations for the Wazuh manager and Filebeat. ([#3059](https://github.com/wazuh/wazuh-packages/pull/3059))


### PR DESCRIPTION
# Description

The purpose of this PR is to migrate the Jenkins pipeline responsible for building the various files of the installation assistant to GitHub Actions.

The built files are copied to a specific S3 bucket in AWS.

## File naming convention

- Files generated without the `is stage` option will be built using the commit SHA that triggered the workflow (e.g., `wazuh-install-71882dd.sh`). 
- Files created with the `is_stage` option will be generated without the commit SHA (e.g., `wazuh-install.sh`).

## Tests

All the tests performed, including both the workflow execution and testing of the various files, can be seen below:

- https://github.com/wazuh/wazuh-installation-assistant/issues/55#issuecomment-2364046218
- https://github.com/wazuh/wazuh-installation-assistant/issues/55#issuecomment-2371728894

## Related issue

- #55 