### PR TITLE
Added available packages check before installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [5.0.0]
 
+### Added
+
+- Added available packages check before installation ([#80](https://github.com/wazuh/wazuh-installation-assistant/pull/80))
+
 ### Changed
 
 - None

--- a/install_functions/installMain.sh
+++ b/install_functions/installMain.sh
@@ -242,6 +242,7 @@ function main() {
     fi
 
     checks_arch
+    checks_availablePackages
     if [ -n "${ignore}" ]; then
         common_logger -w "Hardware checks ignored."
     else


### PR DESCRIPTION
## Description

Related: #65

The aim of this PR is to add a new logic to the installation assistant to check if the Wazuh central packages are available to install.

With this new development, we avoid that the installation is started when the packages are not available to install. 

## Testing

The complete testing is: https://github.com/wazuh/wazuh-installation-assistant/issues/65#issuecomment-2379463820

A log example when the packages are not available to install:
```console
[root@ip-172-31-41-54 ec2-user]# bash wazuh-install.sh -a -v
27/09/2024 13:46:52 DEBUG: Checking root permissions.
27/09/2024 13:46:52 DEBUG: Checking sudo package.
27/09/2024 13:46:52 INFO: Starting Wazuh installation assistant. Wazuh version: 4.10.1
27/09/2024 13:46:52 INFO: Verbose logging redirected to /var/log/wazuh-install.log
27/09/2024 13:46:52 DEBUG: YUM package manager will be used.
27/09/2024 13:46:52 DEBUG: Checking system distribution.
27/09/2024 13:46:52 DEBUG: Detected distribution name: amzn
27/09/2024 13:46:52 DEBUG: Detected distribution version: 2023
27/09/2024 13:46:52 DEBUG: Checking Wazuh installation.
27/09/2024 13:46:52 DEBUG: Checking system architecture.
27/09/2024 13:46:52 DEBUG: Adding the Wazuh repository.
[wazuh]
gpgcheck=1
gpgkey=https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH
enabled=1
name=EL-${releasever} - Wazuh
baseurl=https://packages-dev.wazuh.com/pre-release/yum/
protect=1
27/09/2024 13:46:53 INFO: Wazuh development repository added.
27/09/2024 13:46:53 ERROR: Package wazuh-indexer (version 4.10.1) is NOT available for installation.
27/09/2024 13:46:53 INFO: --- Removing existing Wazuh installation ---
27/09/2024 13:46:53 DEBUG: Removing GPG key from system.
27/09/2024 13:46:54 INFO: Installation cleaned. Check the /var/log/wazuh-install.log file to learn more about the issue.
[root@ip-172-31-41-54 ec2-user]# 
``` 