### PR TITLE
Fixed API password change to match the user in wazuh.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- None
+- Fixed API password change to match the user in wazuh.yml. ([#81](https://github.com/wazuh/wazuh-installation-assistant/pull/81))
 
 ## [4.10.0]
 

--- a/passwords_tool/passwordsFunctions.sh
+++ b/passwords_tool/passwordsFunctions.sh
@@ -85,6 +85,7 @@ function passwords_changePassword() {
 function passwords_changePasswordApi() {
     #Change API password tool
     if [ -n "${changeall}" ]; then
+        wazuh_yml_user=$(awk '/- default:/ {found=1} found && /username:/ {print $2}' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml)
         for i in "${!api_passwords[@]}"; do
             if [ -n "${wazuh_installed}" ]; then
                 passwords_getApiUserId "${api_users[i]}"
@@ -99,7 +100,7 @@ function passwords_changePasswordApi() {
                     common_logger -nl $"The password for Wazuh API user ${api_users[i]} is ${api_passwords[i]}"
                 fi
             fi
-            if [ "${api_users[i]}" == "wazuh-wui" ] && [ -n "${dashboard_installed}" ]; then
+            if [ "${api_users[i]}" == "${wazuh_yml_user}" ] && [ -n "${dashboard_installed}" ]; then
                 passwords_changeDashboardApiPassword "${api_passwords[i]}"
             fi
         done
@@ -112,7 +113,7 @@ function passwords_changePasswordApi() {
                 common_logger -nl $"The password for Wazuh API user ${nuser} is ${password}"
             fi
         fi
-        if [ "${nuser}" == "wazuh-wui" ] && [ -n "${dashboard_installed}" ]; then
+        if [ "${nuser}" == "${wazuh_yml_user}" ] && [ -n "${dashboard_installed}" ]; then
                 passwords_changeDashboardApiPassword "${password}"
         fi
     fi


### PR DESCRIPTION
related: https://github.com/wazuh/wazuh/issues/22751
related: https://github.com/wazuh/wazuh-installation-assistant/issues/78

## Test

```console
root@ubuntu-jammy:~# bash wazuh-passwords-tool.sh -a -A -au wazuh-wui -ap 8faZTnNdWa12ZlImls7r?iN8IFIK8Wn0
27/09/2024 14:44:33 INFO: Updating the internal users.
27/09/2024 14:44:35 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
27/09/2024 14:44:41 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
27/09/2024 14:45:04 INFO: The password for user admin is cjMnxB.BU6F1Mpd3Ly6qDW?x9JqgiZ7V
27/09/2024 14:45:04 INFO: The password for user anomalyadmin is pW*GfV9nyFN3w35Md8mjr8RL2X3ltzTM
27/09/2024 14:45:04 INFO: The password for user kibanaserver is 6NSFKVfUHjTGTH56bIghkuhenCcZNan*
27/09/2024 14:45:04 INFO: The password for user kibanaro is 3E0C**r7sE9xEQ*1EKeRJeEyTSxDUZ4L
27/09/2024 14:45:04 INFO: The password for user logstash is UHm+?lBntfG4HainQBvE6duu0fW77*AT
27/09/2024 14:45:04 INFO: The password for user readall is OPHafT?uCq8i9j21HhgELfKETKGGM2lM
27/09/2024 14:45:04 INFO: The password for user snapshotrestore is 7rq4f89psdngE?1E?pZey1d3Ou*.UPrx
27/09/2024 14:45:04 WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
27/09/2024 14:45:04 INFO: The password for Wazuh API user wazuh is 8djgQVKPi*zi?NX5vq5PnroxYw3nLVW4
27/09/2024 14:45:06 INFO: The password for Wazuh API user wazuh-wui is begAJ?sdGz62xWl0K4cIZp?wRNE1Xp+E
27/09/2024 14:45:06 INFO: Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service.
```