### PR TITLE
Solve bugs when changing passwords in the manager, indexer and dashboard services.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Solve bugs when changing passwords in the manager, indexer and dashboard services. ([#86](https://github.com/wazuh/wazuh-installation-assistant/pull/86))
 - Fixed typo in Wazuh Installation Assistant. ([#85](https://github.com/wazuh/wazuh-installation-assistant/pull/85))
 - Print on console the wazuh user's password when installing Wazuh server. ([#84](https://github.com/wazuh/wazuh-installation-assistant/pull/84))
 - Improved service status and output management in Installation assistant. ([#82](https://github.com/wazuh/wazuh-installation-assistant/pull/82))

--- a/passwords_tool/passwordsFunctions.sh
+++ b/passwords_tool/passwordsFunctions.sh
@@ -14,6 +14,7 @@ function passwords_changePassword() {
             eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ ${debug}"
             passwords_createBackUp
         fi
+
         for i in "${!passwords[@]}"
         do
             if [ -n "${indexer_installed}" ] && [ -f "/etc/wazuh-indexer/backup/internal_users.yml" ]; then
@@ -61,6 +62,8 @@ function passwords_changePassword() {
             common_logger "The filebeat.yml file has been updated to use the Filebeat Keystore username and password."
             passwords_restartService "filebeat"
             eval "/var/ossec/bin/wazuh-keystore -f indexer -k password -v ${adminpass}"
+            common_logger -nl $"The new password for Filebeat is ${adminpass}"
+
             passwords_restartService "wazuh-manager"
         fi
     fi
@@ -77,6 +80,11 @@ function passwords_changePassword() {
                 echo "${conf}" > /etc/wazuh-dashboard/opensearch_dashboards.yml
             fi
             passwords_restartService "wazuh-dashboard"
+
+            if [ -z "${indexer_installed}" ]; then
+                # only for when the indexer is not installed, so as not to put the same information several times.
+                common_logger -nl $"The password for the kibanaserver user in the dashboard has been updated to $dashpass"
+            fi
         fi
     fi
 
@@ -84,8 +92,10 @@ function passwords_changePassword() {
 
 function passwords_changePasswordApi() {
     #Change API password tool
-    if [ -n "${changeall}" ]; then
+    if [ -f "/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml" ]; then
         wazuh_yml_user=$(awk '/- default:/ {found=1} found && /username:/ {print $2}' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml)
+    fi
+    if [ -n "${changeall}" ]; then
         for i in "${!api_passwords[@]}"; do
             if [ -n "${wazuh_installed}" ]; then
                 passwords_getApiUserId "${api_users[i]}"
@@ -125,8 +135,16 @@ function passwords_changeDashboardApiPassword() {
     until [ -n "${file_exists}" ] || [ "${j}" -eq "12" ]; do
         if [ -f "/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml" ]; then
             eval "sed -i 's|password: .*|password: \"${1}\"|g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml ${debug}"
+            # Restart the service only if we change the api password. If we change all, the service is restarted when changing the kibanaserver password.
+            if [ -z "${changeall}" ]; then
+                passwords_restartService "wazuh-dashboard"
+            fi
             if [ -z "${AIO}" ] && [ -z "${indexer}" ] && [ -z "${dashboard}" ] && [ -z "${wazuh}" ] && [ -z "${start_indexer_cluster}" ]; then
-                common_logger "Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service."
+                if [ -z "${wazuh_installed}" ]; then
+                    common_logger "Updated wazuh-wui user password in wazuh dashboard to '${1}'."
+                else
+                    common_logger "Updated wazuh-wui user password in wazuh dashboard."
+                fi
             fi
             file_exists=1
         fi
@@ -138,19 +156,19 @@ function passwords_changeDashboardApiPassword() {
 
 function passwords_checkUser() {
 
-    if [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; then
+    if { [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; } || { [ -z "${wazuh_installed}" ] && [ -n "${dashboard_installed}" ]; }; then
         for i in "${!api_users[@]}"; do
             if [ "${api_users[i]}" == "${nuser}" ]; then
                 exists=1
             fi
         done
-    else
-        for i in "${!users[@]}"; do
-            if [ "${users[i]}" == "${nuser}" ]; then
-                exists=1
-            fi
-        done
     fi
+
+    for i in "${!users[@]}"; do
+        if [ "${users[i]}" == "${nuser}" ]; then
+            exists=1
+        fi
+    done
 
     if [ -z "${exists}" ]; then
         common_logger -e "The given user does not exist"
@@ -483,7 +501,7 @@ For Wazuh API users, the file must have this format:
             fi
         done
 
-        if [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; then
+        if { [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; } || { [ -z "${wazuh_installed}" ] && [ -n "${dashboard_installed}" ]; } then
             for j in "${!fileapiusers[@]}"; do
                 supported=false
                 for i in "${!api_users[@]}"; do
@@ -512,11 +530,28 @@ For Wazuh API users, the file must have this format:
 
 }
 
+function passwords_readDashboardUsers() {
+
+    wazuh_yml_user=$(awk '/- default:/ {found=1} found && /username:/ {print $2}' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml)
+
+    api_users=("$wazuh_yml_user")
+
+    if [ -z "${indexer_installed}" ]; then
+        users+=("kibanaserver")
+    fi
+
+}
+
 function passwords_readUsers() {
 
-    passwords_updateInternalUsers
-    susers=$(grep -B 1 hash: /etc/wazuh-indexer/opensearch-security/internal_users.yml | grep -v hash: | grep -v "-" | awk '{ print substr( $0, 1, length($0)-1 ) }')
-    mapfile -t users <<< "${susers[@]}"
+    if [ -n "${indexer_installed}" ]; then
+        passwords_updateInternalUsers
+        susers=$(grep -B 1 hash: /etc/wazuh-indexer/opensearch-security/internal_users.yml | grep -v hash: | grep -v "-" | awk '{ print substr( $0, 1, length($0)-1 ) }')
+        mapfile -t users <<< "${susers[@]}"
+    elif  [ -n "${wazuh_installed}" ]; then
+        # Only need the user admin for Filebeat connection
+        users=("admin")
+    fi
 
 }
 

--- a/passwords_tool/passwordsMain.sh
+++ b/passwords_tool/passwordsMain.sh
@@ -228,7 +228,9 @@ function main() {
                 passwords_getApiToken
                 passwords_getApiUsers
                 passwords_getApiIds
-            elif [ -n "${indexer_installed}" ]; then
+            elif [ -z "${wazuh_installed}" ] && [ -n "${dashboard_installed}" ]; then
+                passwords_readDashboardUsers
+            elif [ -n "${indexer_installed}" ] || [ -n "${wazuh_installed}" ]; then
                 passwords_readUsers
             fi
             passwords_checkUser
@@ -242,18 +244,23 @@ function main() {
         if [ -n "${nuser}" ] && [ -n "${password}" ]; then
             passwords_checkPassword "${password}"
         fi
-        
+
 
         if [ -n "${changeall}" ] || [ -n "${p_file}" ]; then
-            if [ -n "${indexer_installed}" ]; then
+            if [ -n "${indexer_installed}" ] || [ -n "${wazuh_installed}" ]; then
                 passwords_readUsers
             fi
-            if [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; then
-                passwords_getApiToken
-                passwords_getApiUsers
-                passwords_getApiIds
-            else
-                common_logger "Wazuh API admin credentials not provided, Wazuh API passwords not changed."
+
+            if [ -n "${wazuh_installed}" ]; then
+                if [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; then
+                    passwords_getApiToken
+                    passwords_getApiUsers
+                    passwords_getApiIds
+                else
+                    common_logger "Wazuh API admin credentials not provided, Wazuh API passwords not changed."
+                fi
+            elif  [ -n "${dashboard_installed}" ]; then
+                passwords_readDashboardUsers
             fi
             if [ -n "${changeall}" ]; then
                 passwords_generatePassword
@@ -272,8 +279,13 @@ function main() {
             passwords_runSecurityAdmin
         fi
 
+        # Call the function to change the password for filebeat and/or kibanaserver
+        if [ -z "${indexer_installed}" ] && { [ -n "${wazuh_installed}" ] || [ -n "${dashboard_installed}" ]; }; then
+            passwords_changePassword
+        fi
+
         if [ -n "${api}" ] || [ -n "${changeall}" ]; then
-            if [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; then
+            if { [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; } || { [ -z "${wazuh_installed}" ] && [ -n "${dashboard_installed}" ]; }; then
                 passwords_changePasswordApi
             fi
         fi


### PR DESCRIPTION
related: https://github.com/wazuh/wazuh-packages/pull/2968
related: https://github.com/wazuh/wazuh-installation-assistant/issues/78

## Test

```console
root@ubuntu-jammy:~# bash wazuh-passwords-tool.sh -gf wazuh-passwords_update.txt.
root@ubuntu-jammy:~# cat wazuh-passwords_update.txt. 
# Admin user for the web user interface and Wazuh indexer. Use this user to log in to Wazuh dashboard
  indexer_username: 'admin'
  indexer_password: '6bmHa3u7Pa5F50c1G2MI*MG+efnpLLQn'

# Anomaly detection user for the web user interface
  indexer_username: 'anomalyadmin'
  indexer_password: 'uGFBKFriTfo1Y5h24Sj9GRq?LgE5seG5'

# Wazuh dashboard user for establishing the connection with Wazuh indexer
  indexer_username: 'kibanaserver'
  indexer_password: 'celNOV1OuepZXdsR*2ePm6xHFaSsnUkD'

# Regular Dashboard user, only has read permissions to all indices and all permissions on the .kibana index
  indexer_username: 'kibanaro'
  indexer_password: '6tf+S8.S4Xn0L91aU.59Nqy27K54XCTt'

# Filebeat user for CRUD operations on Wazuh indices
  indexer_username: 'logstash'
  indexer_password: 'eThLjeuchqqbG9w?CKUv.oLXPmGXxw90'

# User with READ access to all indices
  indexer_username: 'readall'
  indexer_password: '0os81flsm0syuijbsXZZRAFSbz+LVmJk'

# User with permissions to perform snapshot and restore operations
  indexer_username: 'snapshotrestore'
  indexer_password: '*+25PBMi1st*CRg4ajeA.FkNQWgz.5Ja'

# Password for wazuh API user
  api_username: 'wazuh'
  api_password: 'C3zy1Epi?iPwVm6g8zlNiGBHtn.vQc?m'

# Password for wazuh-wui API user
  api_username: 'wazuh-wui'
  api_password: '5Otn2le+ceEPRscGtTyDLTTM.Bl4v5*d'

root@ubuntu-jammy:~# bash wazuh-passwords-tool.sh --change-all -f wazuh-passwords_update.txt.
30/09/2024 13:57:58 INFO: Updating the internal users.
30/09/2024 13:58:00 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
30/09/2024 13:58:00 INFO: Wazuh API admin credentials not provided, Wazuh API passwords not changed.
30/09/2024 13:58:05 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
30/09/2024 13:58:06 INFO: The new password for Filebeat is 6bmHa3u7Pa5F50c1G2MI*MG+efnpLLQn
30/09/2024 13:58:31 INFO: The password for user admin is 6bmHa3u7Pa5F50c1G2MI*MG+efnpLLQn
30/09/2024 13:58:31 INFO: The password for user anomalyadmin is uGFBKFriTfo1Y5h24Sj9GRq?LgE5seG5
30/09/2024 13:58:31 INFO: The password for user kibanaserver is celNOV1OuepZXdsR*2ePm6xHFaSsnUkD
30/09/2024 13:58:31 INFO: The password for user kibanaro is 6tf+S8.S4Xn0L91aU.59Nqy27K54XCTt
30/09/2024 13:58:31 INFO: The password for user logstash is eThLjeuchqqbG9w?CKUv.oLXPmGXxw90
30/09/2024 13:58:31 INFO: The password for user readall is 0os81flsm0syuijbsXZZRAFSbz+LVmJk
30/09/2024 13:58:31 INFO: The password for user snapshotrestore is *+25PBMi1st*CRg4ajeA.FkNQWgz.5Ja
30/09/2024 13:58:31 WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
root@ubuntu-jammy:~# filebeat test output
elasticsearch: https://127.0.0.1:9200...
  parse url... OK
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 127.0.0.1
    dial up... OK
  TLS...
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.2
    dial up... OK
  talk to server... OK
  version: 7.10.2
```