### PR TITLE
Added check when generating certificates for multiple DNS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Added check when generating certificates for multiple DNS. ([#88](https://github.com/wazuh/wazuh-installation-assistant/pull/88))
 - Change cert-tool to use only one wazuh-certificates folder. ([#87](https://github.com/wazuh/wazuh-installation-assistant/pull/87))
 - Solve bugs when changing passwords in the manager, indexer and dashboard services. ([#86](https://github.com/wazuh/wazuh-installation-assistant/pull/86))
 - Fixed typo in Wazuh Installation Assistant. ([#85](https://github.com/wazuh/wazuh-installation-assistant/pull/85))

--- a/cert_tool/certFunctions.sh
+++ b/cert_tool/certFunctions.sh
@@ -368,11 +368,15 @@ function cert_readConfig() {
 
         for ip in "${all_ips[@]}"; do
             isIP=$(echo "${ip}" | grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$")
+                        isDNS=$(echo "${ip}" | grep -P "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\.([A-Za-z]{2,})$" )
             if [[ -n "${isIP}" ]]; then
                 if ! cert_checkPrivateIp "$ip"; then
                     common_logger -e "The IP ${ip} is public."
                     exit 1
                 fi
+            elif [[ -n "${isDNS}" ]]; then
+                common_logger -e "The DNS ${ip} is not valid."
+                exit 1
             fi
         done
 


### PR DESCRIPTION
related: https://github.com/wazuh/wazuh-packages/pull/3006
releated: https://github.com/wazuh/wazuh-installation-assistant/issues/78


## Test

```console
root@ubuntu-jammy:~# cat config.yml 
nodes:
  indexer:
    - name: wazuh-indexer
      ip: www.google.es
  server:
    - name: wazuh-server
      ip: www.google.es
  dashboard:
    - name: wazuh-dashboard
      ip: www.google.es
```

```console
root@ubuntu-jammy:~# bash wazuh-certs-tool.sh -A -v
30/09/2024 14:53:59 INFO: Verbose logging redirected to /root/wazuh-certificates-tool.log
30/09/2024 14:53:59 DEBUG: Reading configuration file.
30/09/2024 14:53:59 ERROR: The DNS www.google.es is not valid.

```