### PR TITLE
Added architecture information to assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Added architecture information to assistant. ([#92](https://github.com/wazuh/wazuh-installation-assistant/pull/92))
 
 ### Deleted
 

--- a/install_functions/checks.sh
+++ b/install_functions/checks.sh
@@ -12,7 +12,7 @@ function checks_arch() {
     arch=$(uname -m)
 
     if [ "${arch}" != "x86_64" ]; then
-        common_logger -e "Uncompatible system. This script must be run on a 64-bit system."
+        common_logger -e "Uncompatible system. This script must be run on a 64-bit (x86_64/AMD64) system."
         exit 1
     fi
 }

--- a/install_functions/installMain.sh
+++ b/install_functions/installMain.sh
@@ -243,7 +243,7 @@ function main() {
         exit 0
     fi
 
-    common_logger "Starting Wazuh installation assistant. Wazuh version: ${wazuh_version}"
+    common_logger "Starting Wazuh installation assistant. Wazuh version: ${wazuh_version} (x86_64/AMD64)"
     common_logger "Verbose logging redirected to ${logfile}"
 
 # -------------- Uninstall case  ------------------------------------


### PR DESCRIPTION
## Descrption

Closes: https://github.com/wazuh/wazuh-installation-assistant/issues/83
The aim of this PR is to add more information about the supported architecture when performing an installation using the Wazuh installation assistant.

With this new development, it is clarified that the supported architecture is x86_64/AMD64.


```console
[root@ip-172-31-21-245 ec2-user]# bash wazuh-install.sh -a -v
02/10/2024 13:31:01 DEBUG: Checking root permissions.
02/10/2024 13:31:01 DEBUG: Checking sudo package.
02/10/2024 13:31:01 INFO: Starting Wazuh installation assistant. Wazuh version: 4.10.1 (x86_64/AMD64)
02/10/2024 13:31:01 INFO: Verbose logging redirected to /var/log/wazuh-install.log
02/10/2024 13:31:01 DEBUG: YUM package manager will be used.
02/10/2024 13:31:01 DEBUG: Checking system distribution.
02/10/2024 13:31:01 DEBUG: Detected distribution name: amzn
02/10/2024 13:31:01 DEBUG: Detected distribution version: 2
02/10/2024 13:31:01 DEBUG: Installing check dependencies.
02/10/2024 13:31:02 DEBUG: Checking Wazuh installation.
02/10/2024 13:31:02 DEBUG: Checking system architecture.
02/10/2024 13:31:02 ERROR: Uncompatible system. This script must be run on a 64-bit (x86_64/AMD64) system.
[root@ip-172-31-21-245 ec2-user]# 
```
