### PR TITLE
Add input for wazuh installation assistant reference in workflows

### DIFF
--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -20,6 +20,10 @@ on:
         options:
           - staging
           - pre-release
+      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
+        description: 'Branch or tag of the wazuh-installation-assistant repository'
+        required: true
+        default: '4.10.0'
       AUTOMATION_REFERENCE:
         description: 'Branch or tag of the wazuh-automation repository'
         required: true
@@ -71,6 +75,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
 
     - name: View parameters
       run: echo "${{ toJson(inputs) }}"

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -20,6 +20,10 @@ on:
         options:
           - staging
           - pre-release
+      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
+        description: 'Branch or tag of the wazuh-installation-assistant repository'
+        required: true
+        default: '4.10.0'
       AUTOMATION_REFERENCE:
         description: 'Branch or tag of the wazuh-automation repository'
         required: true
@@ -73,6 +77,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
 
     - name: View parameters
       run: echo "${{ toJson(inputs) }}"

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -47,7 +47,7 @@ jobs:
         run: echo "${{ toJson(inputs) }}"
 
       - name: Checkout wazuh-installation-assistant repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
       

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -4,6 +4,10 @@ name: Build Installation Assistant
 on:
   workflow_dispatch:
     inputs:
+      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
+        description: "Branch or tag of the wazuh-installation-assistant repository."
+        required: true
+        default: 4.10.0
       is_stage:
         description: "Is stage?"
         type: boolean
@@ -44,6 +48,8 @@ jobs:
 
       - name: Checkout wazuh-installation-assistant repository
         uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
       
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -5,6 +5,11 @@ on:
       - 'install_functions/wazuh-offline-download.sh'
       - 'install_functions/wazuh-offline-installation.sh'
   workflow_dispatch:
+    inputs:
+      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
+        description: "Branch or tag of the wazuh-installation-assistant repository."
+        required: true
+        default: 4.10.0
 
 jobs:
   Build-wazuh-install-script:
@@ -18,6 +23,8 @@ jobs:
           skip_after_successful_duplicate: 'false'
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
 
       - name: Build wazuh-install script and use staging packages
         run: bash builder.sh -i
@@ -33,6 +40,8 @@ jobs:
     needs: Build-wazuh-install-script
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
 
       - uses: actions/download-artifact@v3
         with:
@@ -49,6 +58,8 @@ jobs:
     needs: Build-wazuh-install-script
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
 
       - uses: actions/download-artifact@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Add input for wazuh installation assistant reference in workflows. ([#98](https://github.com/wazuh/wazuh-installation-assistant/pull/98))
 - Create GHA workflow to build Wazuh Installation Assistant files. ([#77](https://github.com/wazuh/wazuh-installation-assistant/pull/77))
 - Installation assistant distributed test rework and migration. ([#60](https://github.com/wazuh/wazuh-installation-assistant/pull/60))
 - Installation assistant test and tier workflow migration ([#46](https://github.com/wazuh/wazuh-installation-assistant/pull/46/))


### PR DESCRIPTION
### Related issue
Closes https://github.com/wazuh/wazuh-installation-assistant/issues/97

# Description
The aim of this PR is to add a new `WAZUH_INSTALLATION_ASSISTANT_REFERENCE` input to the `builder_installation_assistant`, `offline-installation`, `Test_installation_assistant_distributed` and `Test_installation_assistant` workflows.

## Tests
- Running the `builder_installation_assistant` workflow:
![build-ia](https://github.com/user-attachments/assets/539c10f0-e514-4cd6-8924-e734c6da5a66)

- Running the `offline-installation` workflow:
![offline](https://github.com/user-attachments/assets/ec3df017-312f-4703-a7ca-3c3d2e5e8cd7)

- Running the `Test_installation_assistant_distributed` workflow:
![test-ia-distributed](https://github.com/user-attachments/assets/9a08e0e5-5484-478a-91f8-fc02506b0cdc)

- Running the `Test_installation_assistant` workflow:
![test-ia](https://github.com/user-attachments/assets/d34f033a-3265-4b7b-8666-4d0015d1afdd)
