### PR TITLE
Add checksum input and update the upload files to S3 steps

### DIFF
--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -89,9 +89,9 @@ jobs:
       
       - name: Save files name
         run: |
-          WAZUH_INSTALL_NAME=$(ls ${{ github.workspace }}/${{ env.WAZUH_INSTALL_NAME }}*.sh)
-          WAZUH_CERT_TOOL_NAME=$(ls ${{ github.workspace }}/${{ env.WAZUH_CERT_TOOL_NAME }}*.sh)
-          WAZUH_PASSWORD_TOOL_NAME=$(ls ${{ github.workspace }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }}*.sh)
+          WAZUH_INSTALL_NAME=$(ls ${{ github.workspace }}/${{ env.WAZUH_INSTALL_NAME }}*.sh | xargs basename)
+          WAZUH_CERT_TOOL_NAME=$(ls ${{ github.workspace }}/${{ env.WAZUH_CERT_TOOL_NAME }}*.sh | xargs basename)
+          WAZUH_PASSWORD_TOOL_NAME=$(ls ${{ github.workspace }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }}*.sh | xargs basename)
           echo "WAZUH_INSTALL_NAME=$WAZUH_INSTALL_NAME" >> $GITHUB_ENV
           echo "WAZUH_CERT_TOOL_NAME=$WAZUH_CERT_TOOL_NAME" >> $GITHUB_ENV
           echo "WAZUH_PASSWORD_TOOL_NAME=$WAZUH_PASSWORD_TOOL_NAME" >> $GITHUB_ENV

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -4,7 +4,7 @@ name: Build Installation Assistant
 on:
   workflow_dispatch:
     inputs:
-      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
+      wazuh_installation_assistant_reference:
         description: "Branch or tag of the wazuh-installation-assistant repository."
         required: true
         default: 4.10.0
@@ -22,7 +22,7 @@ on:
         required: false
   workflow_call:
     inputs:
-      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
+      wazuh_installation_assistant_reference:
         description: "Branch or tag of the wazuh-installation-assistant repository."
         type: string
         required: true
@@ -40,7 +40,7 @@ on:
         required: false
 
 env:
-  S3_BUCKET: "packages-dev.internal.wazuh.com"
+  S3_BUCKET: ${{ vars.AWS_S3_BUCKET}}
   S3_REPOSITORY_PATH: "development/wazuh/4.x/secondary/installation-assistant"
   BUILDER_PATH: "builder.sh"
   WAZUH_INSTALL_NAME: "wazuh-install"
@@ -62,7 +62,7 @@ jobs:
       - name: Checkout wazuh-installation-assistant repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+          ref: ${{ inputs.wazuh_installation_assistant_reference }}
       
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v3
@@ -127,7 +127,7 @@ jobs:
         run: |
           aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}.sha512 s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}.sha512"
-          echo "S3 sha512 wazuh-install-tool checksum URI: ${s3uri}"
+          echo "S3 sha512 wazuh-install checksum URI: ${s3uri}"
           aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}.sha512 s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}.sha512"
           echo "S3 sha512 wazuh-certs-tool checksum URI: ${s3uri}"

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -12,14 +12,27 @@ on:
         description: "Is stage?"
         type: boolean
         default: false
+      checksum:
+        description: "Add checksum"
+        type: boolean
+        default: false
       id:
         description: "ID used to identify the workflow uniquely."
         type: string
         required: false
   workflow_call:
     inputs:
+      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
+        description: "Branch or tag of the wazuh-installation-assistant repository."
+        type: string
+        required: true
+        default: 4.10.0
       is_stage:
         description: "Is stage?"
+        type: boolean
+        default: false
+      checksum:
+        description: "Add checksum"
         type: boolean
         default: false
       id:
@@ -73,14 +86,37 @@ jobs:
 
       - name: Build Installation Assistant packages
         run: bash builder.sh -i -c -p
+      
+      - name: Save files name
+        run: |
+          WAZUH_INSTALL_NAME=$(ls ${{ github.workspace }}/${{ env.WAZUH_INSTALL_NAME }}*.sh)
+          WAZUH_CERT_TOOL_NAME=$(ls ${{ github.workspace }}/${{ env.WAZUH_CERT_TOOL_NAME }}*.sh)
+          WAZUH_PASSWORD_TOOL_NAME=$(ls ${{ github.workspace }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }}*.sh)
+          echo "WAZUH_INSTALL_NAME=$WAZUH_INSTALL_NAME" >> $GITHUB_ENV
+          echo "WAZUH_CERT_TOOL_NAME=$WAZUH_CERT_TOOL_NAME" >> $GITHUB_ENV
+          echo "WAZUH_PASSWORD_TOOL_NAME=$WAZUH_PASSWORD_TOOL_NAME" >> $GITHUB_ENV
 
       - name: Prepare files
         run: |
           mkdir -p ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
-          mv ${{ env.WAZUH_INSTALL_NAME }}*.sh ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
-          mv ${{ env.WAZUH_CERT_TOOL_NAME }}*.sh ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
-          mv ${{ env.WAZUH_PASSWORD_TOOL_NAME }}*.sh ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
-     
-      - name: Upload files to S3
+          mv ${{ env.WAZUH_INSTALL_NAME }} ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
+          mv ${{ env.WAZUH_CERT_TOOL_NAME }} ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
+          mv ${{ env.WAZUH_PASSWORD_TOOL_NAME }} ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
+      
+      - name: Build packages checksum
+        if: ${{ inputs.checksum == true }}
         run: |
-          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }} --recursive
+          sha512sum ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }} > ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}.sha512
+          sha512sum ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }} > ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}.sha512
+          sha512sum ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }} > ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }}.sha512
+      
+      - name: Build test artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wazuh-installation-assistant-${{ env.WAZUH_VERSION }}
+          path: ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
+
+      # - name: Upload files to S3
+      #   run: |
+      #     aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }} --recursive

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}"
-          echo "S3 wazuh-install URI: ${s3uri}"
+          echo "S3 wazuh-install-tool URI: ${s3uri}"
           aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}"
           echo "S3 wazuh-certs-tool URI: ${s3uri}"
@@ -127,7 +127,7 @@ jobs:
         run: |
           aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}.sha512 s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}.sha512"
-          echo "S3 sha512 wazuh-install checksum URI: ${s3uri}"
+          echo "S3 sha512 wazuh-install-tool checksum URI: ${s3uri}"
           aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}.sha512 s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}.sha512"
           echo "S3 sha512 wazuh-certs-tool checksum URI: ${s3uri}"

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -110,13 +110,27 @@ jobs:
           sha512sum ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }} > ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}.sha512
           sha512sum ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }} > ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }}.sha512
       
-      - name: Build test artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: wazuh-installation-assistant-${{ env.WAZUH_VERSION }}
-          path: ${{ github.workspace }}/${{ env.WAZUH_VERSION }}
+      - name: Upload files to S3
+        run: |
+          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}
+          s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}"
+          echo "S3 wazuh-install URI: ${s3uri}"
+          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}
+          s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}"
+          echo "S3 wazuh-certs-tool URI: ${s3uri}"
+          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}
+          s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }}"
+          echo "S3 wazuh-passwords-tool URI: ${s3uri}"
 
-      # - name: Upload files to S3
-      #   run: |
-      #     aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }} --recursive
+      - name: Upload checksum files to S3
+        if: ${{ inputs.checksum == true }}
+        run: |
+          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}.sha512 s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}
+          s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}.sha512"
+          echo "S3 sha512 wazuh-install checksum URI: ${s3uri}"
+          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}.sha512 s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}
+          s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}.sha512"
+          echo "S3 sha512 wazuh-certs-tool checksum URI: ${s3uri}"
+          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }}.sha512 s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}
+          s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }}.sha512"
+          echo "S3 sha512 wazuh-passwords-tool checksum URI: ${s3uri}"

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -40,7 +40,7 @@ on:
         required: false
 
 env:
-  S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+  S3_BUCKET: "packages-dev.internal.wazuh.com"
   S3_REPOSITORY_PATH: "development/wazuh/4.x/secondary/installation-assistant"
   BUILDER_PATH: "builder.sh"
   WAZUH_INSTALL_NAME: "wazuh-install"

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}"
-          echo "S3 wazuh-install-tool URI: ${s3uri}"
+          echo "S3 wazuh-install URI: ${s3uri}"
           aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}"
           echo "S3 wazuh-certs-tool URI: ${s3uri}"

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -40,7 +40,7 @@ on:
         required: false
 
 env:
-  S3_BUCKET: ${{ vars.AWS_S3_BUCKET}}
+  S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
   S3_REPOSITORY_PATH: "development/wazuh/4.x/secondary/installation-assistant"
   BUILDER_PATH: "builder.sh"
   WAZUH_INSTALL_NAME: "wazuh-install"

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -112,25 +112,25 @@ jobs:
       
       - name: Upload files to S3
         run: |
-          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}
+          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}"
           echo "S3 wazuh-install URI: ${s3uri}"
-          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}
+          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}"
           echo "S3 wazuh-certs-tool URI: ${s3uri}"
-          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}
+          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }} s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }}"
           echo "S3 wazuh-passwords-tool URI: ${s3uri}"
 
       - name: Upload checksum files to S3
         if: ${{ inputs.checksum == true }}
         run: |
-          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}.sha512 s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}
+          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}.sha512 s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_INSTALL_NAME }}.sha512"
           echo "S3 sha512 wazuh-install checksum URI: ${s3uri}"
-          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}.sha512 s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}
+          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}.sha512 s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_CERT_TOOL_NAME }}.sha512"
           echo "S3 sha512 wazuh-certs-tool checksum URI: ${s3uri}"
-          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }}.sha512 s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}
+          aws s3 cp ${{ github.workspace }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }}.sha512 s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/
           s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_REPOSITORY_PATH }}/${{ env.WAZUH_VERSION }}/${{ env.WAZUH_PASSWORD_TOOL_NAME }}.sha512"
           echo "S3 sha512 wazuh-passwords-tool checksum URI: ${s3uri}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Add checksum input and update the upload files to S3 steps ([#106](https://github.com/wazuh/wazuh-installation-assistant/pull/106))
 - Deleted the offline_checkDependencies function and unified logic in offline_checkPrerequisites function. ([#99](https://github.com/wazuh/wazuh-installation-assistant/pull/99))
 - Add input for wazuh installation assistant reference in workflows. ([#98](https://github.com/wazuh/wazuh-installation-assistant/pull/98))
 - Create GHA workflow to build Wazuh Installation Assistant files. ([#77](https://github.com/wazuh/wazuh-installation-assistant/pull/77))


### PR DESCRIPTION
# Description

The goal of this PR is to add the mandatory checksum field to the workflow for building the installation assistant packages.

With this, a new step has been added to generate the `sha512` files and another step to upload them to S3.

Additionally, an `echo` with the URI of each file uploaded to S3 has been added to better identify it.

>[!NOTE]
> This step implies that we have to upload the installation assistant files one by one to correctly obtain the URI of each file.

## Workflow output test

- https://github.com/wazuh/wazuh-installation-assistant/actions/runs/11295854932

## Related issue

- #105 