### PR TITLE
Fix installation assistant tests workflows Python error

### DIFF
--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -120,7 +120,7 @@ jobs:
         echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
 
     - name: Install Ansible
-      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16 --break-system-packages
+      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16
 
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -138,7 +138,7 @@ jobs:
         path: wazuh-automation
 
     - name: Install and set allocator requirements
-      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt --break-system-packages
+      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
 
     - name: Allocate instance test and set SSH variables
       id: allocator_instance

--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -66,7 +66,7 @@ permissions:
 
 jobs:
   run-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false    # If a job fails, the rest of jobs will not be canceled
       matrix:
@@ -119,8 +119,16 @@ jobs:
         COMPOSITE_NAME="${COMPOSITE_NAME/SUBNAME/$SUBNAME}"
         echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
 
+    - name: Install Python and create virtual environment
+      run: |
+        sudo apt-get update
+        sudo apt install -y python3 && sudo apt-get install python3-venv
+        python3 -m venv test_wia_env
+
     - name: Install Ansible
-      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16
+      run: |
+        source test_wia_env/bin/activate
+        python3 -m pip install --user ansible-core==2.16
 
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -138,11 +146,14 @@ jobs:
         path: wazuh-automation
 
     - name: Install and set allocator requirements
-      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
+      run: |
+        source test_wia_env/bin/activate
+        python3 -m pip install -r wazuh-automation/deployability/deps/requirements.txt
 
     - name: Allocate instance test and set SSH variables
       id: allocator_instance
       run: |
+        source test_wia_env/bin/activate
         python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir $ALLOCATOR_PATH \
           --track-output $ALLOCATOR_PATH/track.yml --inventory-output $ALLOCATOR_PATH/inventory.yml --instance-name gha_${{ github.run_id }}_assistant_test \
           --label-team devops --label-termination-date 1d
@@ -156,6 +167,7 @@ jobs:
 
     - name: Execute provision playbook
       run: |
+        source test_wia_env/bin/activate
         INSTALL_DEPS=true
         INSTALL_PYTHON=true
         INSTALL_PIP_DEPS=true
@@ -173,6 +185,7 @@ jobs:
 
     - name: Execute AIO installation playbook
       run: |
+        source test_wia_env/bin/activate
         ansible-playbook .github/workflows/ansible-playbooks/aio.yml \
         -i $ALLOCATOR_PATH/inventory \
         -l all \
@@ -184,6 +197,7 @@ jobs:
 
     - name: Execute Python test playbook
       run: |
+        source test_wia_env/bin/activate
         TEST_NAME="test_installation_assistant"
         ansible-playbook .github/workflows/ansible-playbooks/aio_tests.yml \
         -i $ALLOCATOR_PATH/inventory \
@@ -208,5 +222,7 @@ jobs:
 
     - name: Delete allocated VM
       if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == true
-      run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output $ALLOCATOR_PATH/track.yml
+      run: |
+        source test_wia_env/bin/activate
+        python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output $ALLOCATOR_PATH/track.yml
 

--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -128,7 +128,7 @@ jobs:
     - name: Install Ansible
       run: |
         source test_wia_env/bin/activate
-        python3 -m pip install --user ansible-core==2.16
+        python3 -m pip install ansible-core==2.16
 
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -120,7 +120,7 @@ jobs:
         echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
 
     - name: Install Ansible
-      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16
+      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16 --break-system-packages
       
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -138,7 +138,7 @@ jobs:
         path: wazuh-automation
 
     - name: Install and set allocator requirements
-      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
+      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt --break-system-packages
 
     - name: Allocate instance test and set SSH variables
       id: allocator_instance

--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -1,5 +1,5 @@
 run-name: Test installation assistant - ${{ github.run_id }} - ${{ inputs.SYSTEMS }} - Launched by @${{ github.actor }}
-name: Test installation assistant 
+name: Test installation assistant
 
 on:
   pull_request:
@@ -80,7 +80,7 @@ jobs:
 
     - name: View parameters
       run: echo "${{ toJson(inputs) }}"
-    
+
     - name: Set COMPOSITE_NAME variable
       run: |
         case "${{ matrix.system }}" in
@@ -120,8 +120,8 @@ jobs:
         echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
 
     - name: Install Ansible
-      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16 --break-system-packages
-      
+      run: sudo apt-get update && sudo apt install -y python3.10 python3.10-venv python3.10-dev && python3 -m pip install --user ansible-core==2.16 --break-system-packages
+
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -150,7 +150,7 @@ jobs:
         sed 's/: */=/g' $ALLOCATOR_PATH/inventory.yml > $ALLOCATOR_PATH/inventory_mod.yml
         sed -i 's/-o StrictHostKeyChecking=no/\"-o StrictHostKeyChecking=no\"/g' $ALLOCATOR_PATH/inventory_mod.yml
         source $ALLOCATOR_PATH/inventory_mod.yml
-        
+
         echo "[gha_instance]" > $ALLOCATOR_PATH/inventory
         echo "$ansible_host ansible_port=$ansible_port ansible_user=$ansible_user ansible_ssh_private_key_file=$ansible_ssh_private_key_file ansible_ssh_common_args='$ansible_ssh_common_args'" >> $ALLOCATOR_PATH/inventory
 
@@ -192,13 +192,13 @@ jobs:
         -e "logs_path=$LOGS_PATH" \
         -e "test_name=$TEST_NAME" \
         "${{ inputs.VERBOSITY }}"
-    
+
     - name: Compress Allocator VM directory
       id: compress_allocator_files
       if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == false
       run: |
         zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r $ALLOCATOR_PATH.zip $ALLOCATOR_PATH
-      
+
     - name: Upload Allocator VM directory as artifact
       if: always() && steps.compress_allocator_files.outcome == 'success' && inputs.DESTROY == false
       uses: actions/upload-artifact@v4
@@ -209,4 +209,4 @@ jobs:
     - name: Delete allocated VM
       if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == true
       run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output $ALLOCATOR_PATH/track.yml
-      
+

--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -66,7 +66,7 @@ permissions:
 
 jobs:
   run-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false    # If a job fails, the rest of jobs will not be canceled
       matrix:
@@ -120,7 +120,7 @@ jobs:
         echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
 
     - name: Install Ansible
-      run: sudo apt-get update && sudo apt install -y python3.10 python3.10-venv python3.10-dev && python3 -m pip install --user ansible-core==2.16 --break-system-packages
+      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16 --break-system-packages
 
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -122,7 +122,7 @@ jobs:
         echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
 
     - name: Install Ansible
-      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16 && pip install pyyaml && ansible-galaxy collection install community.general
+      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16 --break-system-packages && pip install pyyaml --break-system-packages && ansible-galaxy collection install community.general
     
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -140,7 +140,7 @@ jobs:
         path: wazuh-automation
 
     - name: Install and set allocator requirements
-      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
+      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt --break-system-packages
 
     - name: Allocate instances and create inventory
       id: allocator_instance

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -1,5 +1,5 @@
 run-name: (Distributed) Test installation assistant - ${{ github.run_id }} - ${{ inputs.SYSTEMS }} - Launched by @${{ github.actor }}
-name: (Distributed) Test installation assistant 
+name: (Distributed) Test installation assistant
 
 on:
   pull_request:
@@ -68,7 +68,7 @@ permissions:
 
 jobs:
   run-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false    # If a job fails, the rest of jobs will not be canceled
       matrix:
@@ -82,7 +82,7 @@ jobs:
 
     - name: View parameters
       run: echo "${{ toJson(inputs) }}"
-    
+
     - name: Set COMPOSITE_NAME variable
       run: |
         case "${{ matrix.system }}" in
@@ -122,8 +122,8 @@ jobs:
         echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
 
     - name: Install Ansible
-      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16 --break-system-packages && pip install pyyaml --break-system-packages && ansible-galaxy collection install community.general
-    
+      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16 && pip install pyyaml && ansible-galaxy collection install community.general
+
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -140,7 +140,7 @@ jobs:
         path: wazuh-automation
 
     - name: Install and set allocator requirements
-      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt --break-system-packages
+      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
 
     - name: Allocate instances and create inventory
       id: allocator_instance
@@ -158,7 +158,7 @@ jobs:
         echo "[managers]" > $inventory_managers
         echo "[dashboards]" > $inventory_dashboards
         echo "[all:vars]" > $inventory_common
-    
+
         for i in ${!instance_names[@]}; do
           instance_name=${instance_names[$i]}
           # Provision instance in parallel
@@ -184,7 +184,7 @@ jobs:
             if [[ $i -eq 0 ]]; then
               echo "indexer1 ansible_host=$ansible_host private_ip=$private_ip ansible_ssh_private_key_file=$ansible_ssh_private_key_file" >> $inventory_indexers
               echo "master ansible_host=$ansible_host private_ip=$private_ip ansible_ssh_private_key_file=$ansible_ssh_private_key_file manager_type=master instance_type=indexer_manager" >> $inventory_managers
-              
+
               echo "ansible_user=$ansible_user" >> $inventory_common
               echo "ansible_port=$ansible_port" >> $inventory_common
               echo "ansible_ssh_common_args='$ansible_ssh_common_args'" >> $inventory_common
@@ -207,7 +207,7 @@ jobs:
         cat $inventory_managers >> $inventory_file
         cat $inventory_dashboards >> $inventory_file
         cat $inventory_common >> $inventory_file
-    
+
     - name: Execute provision playbook
       run: |
         INSTALL_DEPS=true
@@ -224,14 +224,14 @@ jobs:
         -e "install_python=$INSTALL_PYTHON" \
         -e "install_pip_deps=$INSTALL_PIP_DEPS" \
         "${{ inputs.VERBOSITY }}"
-    
+
     - name: Execute certificates generation playbook
       run: |
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/distributed_generate_certificates.yml \
         -i $ALLOCATOR_PATH/inventory \
         -e "resources_path=$RESOURCES_PATH" \
         "${{ inputs.VERBOSITY }}"
-    
+
     - name: Copy certificates to nodes
       run: |
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/distributed_copy_certificates.yml \
@@ -249,7 +249,7 @@ jobs:
         -e "tmp_path=$TMP_PATH" \
         -e "pkg_repository=$PKG_REPOSITORY" \
         "${{ inputs.VERBOSITY }}"
-    
+
     - name: Execute indexer cluster start playbook
       run: |
         INDEXER_ADMIN_PASSWORD="admin"
@@ -259,7 +259,7 @@ jobs:
         -e "tmp_path=$TMP_PATH" \
         -e "pkg_repository=$PKG_REPOSITORY" \
         "${{ inputs.VERBOSITY }}"
-    
+
     - name: Execute server installation playbook
       run: |
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/distributed_install_wazuh.yml \
@@ -268,7 +268,7 @@ jobs:
         -e "tmp_path=$TMP_PATH" \
         -e "pkg_repository=$PKG_REPOSITORY" \
         "${{ inputs.VERBOSITY }}"
-      
+
     - name: Execute dashboard installation playbook
       run: |
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/distributed_install_dashboard.yml \
@@ -277,7 +277,7 @@ jobs:
         -e "tmp_path=$TMP_PATH" \
         -e "pkg_repository=$PKG_REPOSITORY" \
         "${{ inputs.VERBOSITY }}"
-    
+
     - name: Execute Python test playbook
       run: |
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/distributed_tests.yml \
@@ -286,13 +286,13 @@ jobs:
         -e "tmp_path=$TMP_PATH" \
         -e "test_name=$TEST_NAME" \
         "${{ inputs.VERBOSITY }}"
-    
+
     - name: Compress Allocator VM directory
       id: compress_allocator_files
       if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == false
       run: |
         zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r $ALLOCATOR_PATH.zip $ALLOCATOR_PATH
-      
+
     - name: Upload Allocator VM directory as artifact
       if: always() && steps.compress_allocator_files.outcome == 'success' && inputs.DESTROY == false
       uses: actions/upload-artifact@v4
@@ -304,13 +304,13 @@ jobs:
       if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == true
       run: |
         instance_names=($INSTANCE_NAMES)
-    
+
         for i in ${!instance_names[@]}; do
           instance_name=${instance_names[$i]}
           track_file="$ALLOCATOR_PATH/track_${instance_name}.yml"
-    
+
           echo "Deleting instance: $instance_name using track file $track_file"
-    
+
           (
             # Delete instance
             python3 wazuh-automation/deployability/modules/allocation/main.py \

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -68,7 +68,7 @@ permissions:
 
 jobs:
   run-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false    # If a job fails, the rest of jobs will not be canceled
       matrix:
@@ -121,8 +121,17 @@ jobs:
         COMPOSITE_NAME="${COMPOSITE_NAME/SUBNAME/$SUBNAME}"
         echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
 
+    - name: Install Python and create virtual environment
+      run: |
+        sudo apt-get update
+        sudo apt install -y python3 && sudo apt-get install python3-venv
+        python3 -m venv test_wia_distributed_env
+
     - name: Install Ansible
-      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16 && pip install pyyaml && ansible-galaxy collection install community.general
+      run: |
+        source test_wia_distributed_env/bin/activate
+        python3 -m pip install --user ansible-core==2.16
+        pip install pyyaml && ansible-galaxy collection install community.general
 
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -140,11 +149,14 @@ jobs:
         path: wazuh-automation
 
     - name: Install and set allocator requirements
-      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
+      run: |
+        source test_wia_distributed_env/bin/activate
+        python3 -m pip install -r wazuh-automation/deployability/deps/requirements.txt
 
     - name: Allocate instances and create inventory
       id: allocator_instance
       run: |
+        source test_wia_distributed_env/bin/activate
         instance_names=($INSTANCE_NAMES)
         inventory_file="$ALLOCATOR_PATH/inventory"
         inventory_indexers="$ALLOCATOR_PATH/inventory_indexers"
@@ -210,6 +222,7 @@ jobs:
 
     - name: Execute provision playbook
       run: |
+        source test_wia_distributed_env/bin/activate
         INSTALL_DEPS=true
         INSTALL_PYTHON=true
         INSTALL_PIP_DEPS=true
@@ -227,6 +240,7 @@ jobs:
 
     - name: Execute certificates generation playbook
       run: |
+        source test_wia_distributed_env/bin/activate
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/distributed_generate_certificates.yml \
         -i $ALLOCATOR_PATH/inventory \
         -e "resources_path=$RESOURCES_PATH" \
@@ -234,6 +248,7 @@ jobs:
 
     - name: Copy certificates to nodes
       run: |
+        source test_wia_distributed_env/bin/activate
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/distributed_copy_certificates.yml \
         -i $ALLOCATOR_PATH/inventory \
         -l indexers \
@@ -243,6 +258,7 @@ jobs:
 
     - name: Execute indexer installation playbook
       run: |
+        source test_wia_distributed_env/bin/activate
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/distributed_install_indexer.yml \
         -i $ALLOCATOR_PATH/inventory \
         -l indexers \
@@ -252,6 +268,7 @@ jobs:
 
     - name: Execute indexer cluster start playbook
       run: |
+        source test_wia_distributed_env/bin/activate
         INDEXER_ADMIN_PASSWORD="admin"
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/distributed_start_indexer_cluster.yml \
         -i $ALLOCATOR_PATH/inventory \
@@ -262,6 +279,7 @@ jobs:
 
     - name: Execute server installation playbook
       run: |
+        source test_wia_distributed_env/bin/activate
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/distributed_install_wazuh.yml \
         -i $ALLOCATOR_PATH/inventory \
         -l managers \
@@ -271,6 +289,7 @@ jobs:
 
     - name: Execute dashboard installation playbook
       run: |
+        source test_wia_distributed_env/bin/activate
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/distributed_install_dashboard.yml \
         -i $ALLOCATOR_PATH/inventory \
         -l dashboards \
@@ -280,6 +299,7 @@ jobs:
 
     - name: Execute Python test playbook
       run: |
+        source test_wia_distributed_env/bin/activate
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/distributed_tests.yml \
         -i $ALLOCATOR_PATH/inventory \
         -l managers \
@@ -303,6 +323,7 @@ jobs:
     - name: Delete allocated VMs
       if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == true
       run: |
+        source test_wia_distributed_env/bin/activate
         instance_names=($INSTANCE_NAMES)
 
         for i in ${!instance_names[@]}; do

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -130,7 +130,7 @@ jobs:
     - name: Install Ansible
       run: |
         source test_wia_distributed_env/bin/activate
-        python3 -m pip install --user ansible-core==2.16
+        python3 -m pip install ansible-core==2.16
         pip install pyyaml && ansible-galaxy collection install community.general
 
     - name: Set up AWS credentials

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix installation assistant tests workflows Python error ([#107](https://github.com/wazuh/wazuh-installation-assistant/pull/107))
 - Fixed Wazuh API validation ([#29](https://github.com/wazuh/wazuh-installation-assistant/pull/29))
 - Fixed token variable empty in Wazuh manager check ([#45](https://github.com/wazuh/wazuh-installation-assistant/pull/45))
 - Fixed manager check in distributed deployment ([#52](https://github.com/wazuh/wazuh-installation-assistant/pull/52))


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-automation/issues/1891

# Description
This PR aims to fix the bug found in the workflows due to a newer installed version of Python in the executor node.

## Tests
The tests have been done for both [`Test_installation_assistant.yml`](https://github.com/wazuh/wazuh-installation-assistant/actions/runs/11329943076/job/31506618247) and [`Test_installation_assistant_distributed.yml`](https://github.com/wazuh/wazuh-installation-assistant/actions/runs/11329914358/job/31506522025).

> [!NOTE]  
> Consider that I manually stopped the workflows when the pip and python task were completed.