### PR TITLE
Fixed bug when trying to download nonexistent filebeat_wazuh_template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed bug when trying to download nonexistent filebeat_wazuh_template ([#124](https://github.com/wazuh/wazuh-installation-assistant/pull/124))
 - Fixed offline pre-release package download process ([#121](https://github.com/wazuh/wazuh-installation-assistant/pull/121))
 - Changed GitHub Runner version to fix Python error ([#110](https://github.com/wazuh/wazuh-installation-assistant/pull/110))
 - Fixed Wazuh API validation ([#29](https://github.com/wazuh/wazuh-installation-assistant/pull/29))

--- a/install_functions/indexer.sh
+++ b/install_functions/indexer.sh
@@ -207,7 +207,7 @@ function indexer_startCluster() {
         filebeat_wazuh_template="file://${offline_files_path}/wazuh-template.json"
     fi
     http_status=$(eval "common_curl --silent '${filebeat_wazuh_template}' --max-time 300 --retry 5 --retry-delay 5" | eval "common_curl -X PUT 'https://${indexer_node_ips[pos]}:9200/_template/wazuh' -H \'Content-Type: application/json\' -d @- -uadmin:admin -k --max-time 300 --silent --retry 5 --retry-delay 5 -w "%{http_code}" -o /dev/null")
-    if [ "${http_status}" -ne 200 ]; then
+    if [ "${http_status}" -ne 200 ] || [ -z "${http_status}" ]; then
         common_logger -e "The wazuh-alerts template could not be inserted into the Wazuh indexer cluster."
         exit 1
     else

--- a/install_functions/indexer.sh
+++ b/install_functions/indexer.sh
@@ -207,7 +207,7 @@ function indexer_startCluster() {
         filebeat_wazuh_template="file://${offline_files_path}/wazuh-template.json"
     fi
     http_status=$(eval "common_curl --silent '${filebeat_wazuh_template}' --max-time 300 --retry 5 --retry-delay 5" | eval "common_curl -X PUT 'https://${indexer_node_ips[pos]}:9200/_template/wazuh' -H \'Content-Type: application/json\' -d @- -uadmin:admin -k --max-time 300 --silent --retry 5 --retry-delay 5 -w "%{http_code}" -o /dev/null")
-    if [ "${http_status}" -ne 200 ] || [ -z "${http_status}" ]; then
+    if [ -z "${http_status}" ] || [ "${http_status}" -ne 200 ]; then
         common_logger -e "The wazuh-alerts template could not be inserted into the Wazuh indexer cluster."
         exit 1
     else


### PR DESCRIPTION
## Related issue:
- https://github.com/wazuh/wazuh-installation-assistant/issues/122

# Description
The purpose of this PR is to contemplate the case in which the `filebeat_wazuh_template` cannot be downloaded because the link does not exist and then the execution of the script is stopped.

## Tests

The `source_branch` variable that is defined in this execution is `v4.10.0` and this carries to a link that does not exist.

```shellsession
root@ip-172-31-32-65:/home/ubuntu/wazuh-installation-assistant# bash wazuh-install.sh -wi node-1 -d pre-release
28/10/2024 09:54:42 INFO: Starting Wazuh installation assistant. Wazuh version: 4.10.0
28/10/2024 09:54:42 INFO: Verbose logging redirected to /var/log/wazuh-install.log
28/10/2024 09:54:53 INFO: Verifying that your system meets the recommended minimum hardware requirements.
28/10/2024 09:55:04 INFO: Wazuh development repository added.
28/10/2024 09:55:04 INFO: --- Wazuh indexer ---
28/10/2024 09:55:04 INFO: Starting Wazuh indexer installation.
28/10/2024 09:55:26 INFO: Wazuh indexer installation finished.
28/10/2024 09:55:26 INFO: Wazuh indexer post-install configuration finished.
28/10/2024 09:55:26 INFO: Starting service wazuh-indexer.
28/10/2024 09:55:53 INFO: wazuh-indexer service started.
28/10/2024 09:55:53 INFO: Initializing Wazuh indexer cluster security settings.
28/10/2024 09:55:57 INFO: Wazuh indexer cluster initialized.
28/10/2024 09:55:57 INFO: Installation finished.
root@ip-172-31-32-65:/home/ubuntu/wazuh-installation-assistant# bash wazuh-install.sh --start-cluster
28/10/2024 09:56:05 INFO: Starting Wazuh installation assistant. Wazuh version: 4.10.0
28/10/2024 09:56:05 INFO: Verbose logging redirected to /var/log/wazuh-install.log
28/10/2024 09:56:15 INFO: Verifying that your system meets the recommended minimum hardware requirements.
28/10/2024 09:56:21 INFO: Wazuh indexer cluster security configuration initialized.
28/10/2024 09:56:42 ERROR: The wazuh-alerts template could not be inserted into the Wazuh indexer cluster.
```