### PR TITLE
Add venv to installation assistant workflows

### DIFF
--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -66,7 +66,7 @@ permissions:
 
 jobs:
   run-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false    # If a job fails, the rest of jobs will not be canceled
       matrix:
@@ -118,9 +118,18 @@ jobs:
         esac
         COMPOSITE_NAME="${COMPOSITE_NAME/SUBNAME/$SUBNAME}"
         echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
+    
+    - name: Install python and create virtual environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3 python3-venv
+        python3 -m venv testing_venv
+        source testing_venv/bin/activate
+        python3 -m pip install --upgrade pip
+        echo PATH=$PATH >> $GITHUB_ENV
 
     - name: Install Ansible
-      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16
+      run: pip install ansible-core==2.16
 
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -209,4 +218,3 @@ jobs:
     - name: Delete allocated VM
       if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == true
       run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output $ALLOCATOR_PATH/track.yml
-

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -68,7 +68,7 @@ permissions:
 
 jobs:
   run-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false    # If a job fails, the rest of jobs will not be canceled
       matrix:
@@ -121,8 +121,20 @@ jobs:
         COMPOSITE_NAME="${COMPOSITE_NAME/SUBNAME/$SUBNAME}"
         echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
 
+    - name: Install python and create virtual environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3 python3-venv
+        python3 -m venv testing_venv
+        source testing_venv/bin/activate
+        python3 -m pip install --upgrade pip
+        echo PATH=$PATH >> $GITHUB_ENV
+
     - name: Install Ansible
-      run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16 && pip install pyyaml && ansible-galaxy collection install community.general
+      run: |
+        pip install ansible-core==2.16
+        pip install pyyaml
+        ansible-galaxy collection install community.general
 
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -320,4 +332,3 @@ jobs:
 
         # Wait for all deletion tasks to complete
         wait
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- None
+- Add venv to installation assistant workflows ([#134](https://github.com/wazuh/wazuh-installation-assistant/pull/134))
 
 ### Fixed
 


### PR DESCRIPTION
# Description

Previously, workflows that used Python failed with the new version of the runner that GitHub Actions utilizes. The most effective solution to resolve this issue is to use Python virtual environments (`venvs`). With `venvs`, we can create isolated environments that don’t interfere with the system's Python modules, making it the safest option.

For this, we had to modify two workflows that used Python in their execution:

- Test_installation_assistant
- Test_installation_assistant_distributed

In both workflows, the `venv` was added, and its correct execution was verified.

## Testing

- Test_installation_assistant workflow: https://github.com/wazuh/wazuh-installation-assistant/actions/runs/11669113874/job/32490341393
- Test_installation_assistant_distributed workflow: https://github.com/wazuh/wazuh-installation-assistant/actions/runs/11682347693/job/32529279911

## Related issue

- #109 