### PR TITLE
Add matrix for pull request and fix provision playbook reference in test workflows

### DIFF
--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false    # If a job fails, the rest of jobs will not be canceled
       matrix:
-        system: ${{ github.event_name == 'pull_request' && 'Ubuntu_22' || fromJson(inputs.SYSTEMS) }} # If the worklflow is executed by a PR, set the OSs
+        system: ${{ github.event_name == 'pull_request' && fromJson('["Ubuntu_22"]') || fromJson(inputs.SYSTEMS) }} # If the worklflow is executed by a PR, set the OSs
 
     steps:
     - name: Checkout code

--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -4,6 +4,7 @@ name: Test installation assistant
 on:
   pull_request:
     paths:
+      - '.github/workflows/**'
       - 'cert_tool/**'
       - 'common_functions/**'
       - 'config/**'

--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -50,6 +50,7 @@ on:
         type: boolean
 
 env:
+  WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.ref_name || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
   COMPOSITE_NAME: "linux-SUBNAME-amd64"
   SESSION_NAME: "Installation-Assistant-Test"
   REGION: "us-east-1"
@@ -70,13 +71,13 @@ jobs:
     strategy:
       fail-fast: false    # If a job fails, the rest of jobs will not be canceled
       matrix:
-        system: ${{ fromJson(inputs.SYSTEMS) }}
+        system: ${{ github.event_name == 'pull_request' && 'Ubuntu_22' || fromJson(inputs.SYSTEMS) }} # If the worklflow is executed by a PR, set the OSs
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+        ref: ${{ env.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
 
     - name: View parameters
       run: echo "${{ toJson(inputs) }}"
@@ -164,7 +165,7 @@ jobs:
         -i $ALLOCATOR_PATH/inventory \
         -l all \
         -e "repository=$REPOSITORY_URL" \
-        -e "reference=${{ github.ref_name }}" \
+        -e "reference=${{ env.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}" \
         -e "tmp_path=$TMP_PATH" \
         -e "install_deps=$INSTALL_DEPS" \
         -e "install_python=$INSTALL_PYTHON" \

--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -198,12 +198,12 @@ jobs:
 
     - name: Compress Allocator VM directory
       id: compress_allocator_files
-      if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == false && github.event_name != 'pull_request')
+      if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == false && github.event_name != 'pull_request'
       run: |
         zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r $ALLOCATOR_PATH.zip $ALLOCATOR_PATH
 
     - name: Upload Allocator VM directory as artifact
-      if: always() && steps.compress_allocator_files.outcome == 'success' && (inputs.DESTROY == false && github.event_name != 'pull_request')
+      if: always() && steps.compress_allocator_files.outcome == 'success' && inputs.DESTROY == false && github.event_name != 'pull_request'
       uses: actions/upload-artifact@v4
       with:
         name: allocator-instance-${{ matrix.system }}

--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -52,12 +52,14 @@ on:
 
 env:
   WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.head_ref || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+  AUTOMATION_REFERENCE: ${{ github.event_name == 'pull_request' && '4.10.2' || inputs.AUTOMATION_REFERENCE }}
+  VERBOSITY: ${{ github.event_name == 'pull_request' && '-v' || inputs.VERBOSITY }}
   COMPOSITE_NAME: "linux-SUBNAME-amd64"
   SESSION_NAME: "Installation-Assistant-Test"
   REGION: "us-east-1"
   TMP_PATH: "/tmp/test"
   LOGS_PATH: "${{ github.workspace }}/assistant_logs"
-  PKG_REPOSITORY: "${{ inputs.REPOSITORY }}"
+  PKG_REPOSITORY: ${{ github.event_name == 'pull_request' && 'pre-release' || inputs.REPOSITORY }}
   TEST_NAME: "test_assistant"
   REPOSITORY_URL: "${{ github.server_url }}/${{ github.repository }}.git"
   ALLOCATOR_PATH: "/tmp/allocator_instance"
@@ -135,7 +137,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: wazuh/wazuh-automation
-        ref: ${{ inputs.AUTOMATION_REFERENCE }}
+        ref: ${{ env.AUTOMATION_REFERENCE }}
         token: ${{ secrets.GH_CLONE_TOKEN }}
         path: wazuh-automation
 
@@ -166,12 +168,12 @@ jobs:
         -i $ALLOCATOR_PATH/inventory \
         -l all \
         -e "repository=$REPOSITORY_URL" \
-        -e "reference=${{ env.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}" \
+        -e "reference=$WAZUH_INSTALLATION_ASSISTANT_REFERENCE" \
         -e "tmp_path=$TMP_PATH" \
         -e "install_deps=$INSTALL_DEPS" \
         -e "install_python=$INSTALL_PYTHON" \
         -e "install_pip_deps=$INSTALL_PIP_DEPS" \
-        "${{ inputs.VERBOSITY }}"
+        "$VERBOSITY"
 
     - name: Execute AIO installation playbook
       run: |
@@ -182,7 +184,7 @@ jobs:
         -e "logs_path=$LOGS_PATH" \
         -e "test_name=$TEST_NAME" \
         -e "pkg_repository=$PKG_REPOSITORY" \
-        "${{ inputs.VERBOSITY }}"
+        "$VERBOSITY"
 
     - name: Execute Python test playbook
       run: |
@@ -193,22 +195,22 @@ jobs:
         -e "tmp_path=$TMP_PATH" \
         -e "logs_path=$LOGS_PATH" \
         -e "test_name=$TEST_NAME" \
-        "${{ inputs.VERBOSITY }}"
+        "$VERBOSITY"
 
     - name: Compress Allocator VM directory
       id: compress_allocator_files
-      if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == false
+      if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == false || github.event_name == 'pull_request')
       run: |
         zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r $ALLOCATOR_PATH.zip $ALLOCATOR_PATH
 
     - name: Upload Allocator VM directory as artifact
-      if: always() && steps.compress_allocator_files.outcome == 'success' && inputs.DESTROY == false
+      if: always() && steps.compress_allocator_files.outcome == 'success' && (inputs.DESTROY == false || github.event_name == 'pull_request')
       uses: actions/upload-artifact@v4
       with:
         name: allocator-instance-${{ matrix.system }}
         path: ${{ env.ALLOCATOR_PATH }}.zip
 
     - name: Delete allocated VM
-      if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == true
+      if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == true || github.event_name == 'pull_request')
       run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output $ALLOCATOR_PATH/track.yml
 

--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -51,7 +51,7 @@ on:
         type: boolean
 
 env:
-  WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.ref_name || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+  WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.head_ref || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
   COMPOSITE_NAME: "linux-SUBNAME-amd64"
   SESSION_NAME: "Installation-Assistant-Test"
   REGION: "us-east-1"

--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -4,7 +4,6 @@ name: Test installation assistant
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
       - 'cert_tool/**'
       - 'common_functions/**'
       - 'config/**'
@@ -199,12 +198,12 @@ jobs:
 
     - name: Compress Allocator VM directory
       id: compress_allocator_files
-      if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == false || github.event_name == 'pull_request')
+      if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == false && github.event_name != 'pull_request')
       run: |
         zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r $ALLOCATOR_PATH.zip $ALLOCATOR_PATH
 
     - name: Upload Allocator VM directory as artifact
-      if: always() && steps.compress_allocator_files.outcome == 'success' && (inputs.DESTROY == false || github.event_name == 'pull_request')
+      if: always() && steps.compress_allocator_files.outcome == 'success' && (inputs.DESTROY == false && github.event_name != 'pull_request')
       uses: actions/upload-artifact@v4
       with:
         name: allocator-instance-${{ matrix.system }}
@@ -213,4 +212,3 @@ jobs:
     - name: Delete allocated VM
       if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == true || github.event_name == 'pull_request')
       run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output $ALLOCATOR_PATH/track.yml
-

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -4,7 +4,6 @@ name: (Distributed) Test installation assistant
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
       - 'cert_tool/**'
       - 'common_functions/**'
       - 'config/**'
@@ -324,4 +323,3 @@ jobs:
 
         # Wait for all deletion tasks to complete
         wait
-

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -51,7 +51,7 @@ on:
         type: boolean
 
 env:
-  WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.ref_name || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+  WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.head_ref || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
   COMPOSITE_NAME: "linux-SUBNAME-amd64"
   SESSION_NAME: "Installation-Assistant-Test"
   REGION: "us-east-1"

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -50,6 +50,7 @@ on:
         type: boolean
 
 env:
+  WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.ref_name || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
   COMPOSITE_NAME: "linux-SUBNAME-amd64"
   SESSION_NAME: "Installation-Assistant-Test"
   REGION: "us-east-1"
@@ -72,13 +73,13 @@ jobs:
     strategy:
       fail-fast: false    # If a job fails, the rest of jobs will not be canceled
       matrix:
-        system: ${{ github.event_name == 'pull_request' && '["Ubuntu_22"]' || fromJson(inputs.SYSTEMS) }} # If the worklflow is executed by a PR, set the OSs
+        system: ${{ github.event_name == 'pull_request' && 'Ubuntu_22' || fromJson(inputs.SYSTEMS) }} # If the worklflow is executed by a PR, set the OSs
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+        ref: ${{ env.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
 
     - name: View parameters
       run: echo "${{ toJson(inputs) }}"

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false    # If a job fails, the rest of jobs will not be canceled
       matrix:
-        system: ${{ github.event_name == 'pull_request' && 'Ubuntu_22' || fromJson(inputs.SYSTEMS) }} # If the worklflow is executed by a PR, set the OSs
+        system: ${{ github.event_name == 'pull_request' && fromJson('["Ubuntu_22"]') || fromJson(inputs.SYSTEMS) }} # If the worklflow is executed by a PR, set the OSs
 
     steps:
     - name: Checkout code

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -52,13 +52,15 @@ on:
 
 env:
   WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.head_ref || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+  AUTOMATION_REFERENCE: ${{ github.event_name == 'pull_request' && '4.10.2' || inputs.AUTOMATION_REFERENCE }}
+  VERBOSITY: ${{ github.event_name == 'pull_request' && '-v' || inputs.VERBOSITY }}
   COMPOSITE_NAME: "linux-SUBNAME-amd64"
   SESSION_NAME: "Installation-Assistant-Test"
   REGION: "us-east-1"
   TMP_PATH: "/tmp/test"
   ANSIBLE_CALLBACK: "yaml"
   RESOURCES_PATH: "${{ github.workspace }}"
-  PKG_REPOSITORY: "${{ inputs.REPOSITORY }}"
+  PKG_REPOSITORY: ${{ github.event_name == 'pull_request' && 'pre-release' || inputs.REPOSITORY }}
   TEST_NAME: "test_installation_assistant"
   REPOSITORY_URL: "${{ github.server_url }}/${{ github.repository }}.git"
   ALLOCATOR_PATH: "/tmp/allocator_instance"
@@ -137,7 +139,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: wazuh/wazuh-automation
-        ref: ${{ inputs.AUTOMATION_REFERENCE }}
+        ref: ${{ env.AUTOMATION_REFERENCE }}
         token: ${{ secrets.GH_CLONE_TOKEN }}
         path: wazuh-automation
 
@@ -220,19 +222,19 @@ jobs:
         -i $ALLOCATOR_PATH/inventory \
         -l indexers \
         -e "repository=$REPOSITORY_URL" \
-        -e "reference=${{ env.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}" \
+        -e "reference=$WAZUH_INSTALLATION_ASSISTANT_REFERENCE" \
         -e "tmp_path=$TMP_PATH" \
         -e "install_deps=$INSTALL_DEPS" \
         -e "install_python=$INSTALL_PYTHON" \
         -e "install_pip_deps=$INSTALL_PIP_DEPS" \
-        "${{ inputs.VERBOSITY }}"
+        "$VERBOSITY"
 
     - name: Execute certificates generation playbook
       run: |
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/distributed_generate_certificates.yml \
         -i $ALLOCATOR_PATH/inventory \
         -e "resources_path=$RESOURCES_PATH" \
-        "${{ inputs.VERBOSITY }}"
+        "$VERBOSITY"
 
     - name: Copy certificates to nodes
       run: |
@@ -241,7 +243,7 @@ jobs:
         -l indexers \
         -e "tmp_path=$TMP_PATH" \
         -e "resources_path=$RESOURCES_PATH" \
-        "${{ inputs.VERBOSITY }}"
+        "$VERBOSITY"
 
     - name: Execute indexer installation playbook
       run: |
@@ -250,7 +252,7 @@ jobs:
         -l indexers \
         -e "tmp_path=$TMP_PATH" \
         -e "pkg_repository=$PKG_REPOSITORY" \
-        "${{ inputs.VERBOSITY }}"
+        "$VERBOSITY"
 
     - name: Execute indexer cluster start playbook
       run: |
@@ -260,7 +262,7 @@ jobs:
         -l indexers \
         -e "tmp_path=$TMP_PATH" \
         -e "pkg_repository=$PKG_REPOSITORY" \
-        "${{ inputs.VERBOSITY }}"
+        "$VERBOSITY"
 
     - name: Execute server installation playbook
       run: |
@@ -269,7 +271,7 @@ jobs:
         -l managers \
         -e "tmp_path=$TMP_PATH" \
         -e "pkg_repository=$PKG_REPOSITORY" \
-        "${{ inputs.VERBOSITY }}"
+        "$VERBOSITY"
 
     - name: Execute dashboard installation playbook
       run: |
@@ -278,7 +280,7 @@ jobs:
         -l dashboards \
         -e "tmp_path=$TMP_PATH" \
         -e "pkg_repository=$PKG_REPOSITORY" \
-        "${{ inputs.VERBOSITY }}"
+        "$VERBOSITY"
 
     - name: Execute Python test playbook
       run: |
@@ -287,23 +289,23 @@ jobs:
         -l managers \
         -e "tmp_path=$TMP_PATH" \
         -e "test_name=$TEST_NAME" \
-        "${{ inputs.VERBOSITY }}"
+        "$VERBOSITY"
 
     - name: Compress Allocator VM directory
       id: compress_allocator_files
-      if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == false
+      if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == false || github.event_name == 'pull_request')
       run: |
         zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r $ALLOCATOR_PATH.zip $ALLOCATOR_PATH
 
     - name: Upload Allocator VM directory as artifact
-      if: always() && steps.compress_allocator_files.outcome == 'success' && inputs.DESTROY == false
+      if: always() && steps.compress_allocator_files.outcome == 'success' && (inputs.DESTROY == false || github.event_name == 'pull_request')
       uses: actions/upload-artifact@v4
       with:
         name: allocator-instance-${{ matrix.system }}
         path: ${{ env.ALLOCATOR_PATH }}.zip
 
     - name: Delete allocated VMs
-      if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == true
+      if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == true || github.event_name == 'pull_request')
       run: |
         instance_names=($INSTANCE_NAMES)
 

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -219,7 +219,7 @@ jobs:
         -i $ALLOCATOR_PATH/inventory \
         -l indexers \
         -e "repository=$REPOSITORY_URL" \
-        -e "reference=${{ github.ref_name }}" \
+        -e "reference=${{ env.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}" \
         -e "tmp_path=$TMP_PATH" \
         -e "install_deps=$INSTALL_DEPS" \
         -e "install_python=$INSTALL_PYTHON" \

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -292,12 +292,12 @@ jobs:
 
     - name: Compress Allocator VM directory
       id: compress_allocator_files
-      if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == false || github.event_name == 'pull_request')
+      if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == false && github.event_name != 'pull_request'
       run: |
         zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r $ALLOCATOR_PATH.zip $ALLOCATOR_PATH
 
     - name: Upload Allocator VM directory as artifact
-      if: always() && steps.compress_allocator_files.outcome == 'success' && (inputs.DESTROY == false || github.event_name == 'pull_request')
+      if: always() && steps.compress_allocator_files.outcome == 'success' && inputs.DESTROY == false && github.event_name != 'pull_request'
       uses: actions/upload-artifact@v4
       with:
         name: allocator-instance-${{ matrix.system }}

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -4,6 +4,7 @@ name: (Distributed) Test installation assistant
 on:
   pull_request:
     paths:
+      - '.github/workflows/**'
       - 'cert_tool/**'
       - 'common_functions/**'
       - 'config/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Add matrix for pull request and fix provision playbook reference in test workflows ([#136](https://github.com/wazuh/wazuh-installation-assistant/pull/136))
 - Added architecture information to assistant. ([#92](https://github.com/wazuh/wazuh-installation-assistant/pull/92))
 
 ### Deleted


### PR DESCRIPTION
# Description

The purpose of this PR is to fix various bugs found in the installation assistant's test workflows.

Firstly, Ubuntu 22 has been added to the `Test_installation_assistant` matrix as a system, ensuring it functions correctly on pull requests, and the condition in the `Test_installation_assistant_distributed` matrix has also been fixed.

Additionally, the environment variable `WAZUH_INSTALLATION_ASSISTANT_REFERENCE` has been added so that if a pull request triggers the workflow, it uses the branch that activated it (`github.head_ref`) as a reference. If triggered manually, it will use the corresponding input (`WAZUH_INSTALLATION_ASSISTANT_REFERENCE`).

Lastly, some of the variables used in the workflow, like `VERBOSITY` and `AUTOMATION_REFERENCE`, were only set when the workflow was triggered manually. This caused the steps that required these variables to fail when the workflow was run via a pull request. This has been resolved by adding environment variables with the same names and setting the correct values based on how the workflow was triggered.

## Testing

#### Manually executed workflows

- Test_installation_assistant: https://github.com/wazuh/wazuh-installation-assistant/actions/runs/11707841156/job/32608150945
- Test_installation_assistant_distributed: https://github.com/wazuh/wazuh-installation-assistant/actions/runs/11707851982/job/32608191310

#### Pull Request executed workflows

- Test_installation_assistant: https://github.com/wazuh/wazuh-installation-assistant/actions/runs/11704427875/job/32596856921
- Test_installation_assistant_distributed: https://github.com/wazuh/wazuh-installation-assistant/actions/runs/11704427873/job/32596856896

## Related issue

- #135 