### PR TITLE
Print `getHelp` output when no parameter is passed to the builder script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Print getHelp output when no parameter is passed to the builder script. ([#142](https://github.com/wazuh/wazuh-installation-assistant/pull/142))
 
 ### Deleted
 

--- a/builder.sh
+++ b/builder.sh
@@ -198,6 +198,10 @@ function builder_main() {
 
     umask 066
 
+    if [ $# -eq 0 ]; then
+        getHelp
+    fi
+
     while [ -n "${1}" ]
     do
         case "${1}" in


### PR DESCRIPTION
## Related issue:
- https://github.com/wazuh/wazuh-installation-assistant/issues/24

# Description
The aim of this PR is to run the `getHelp` and show the usage options of the `builder.sh` script.

## Tests
I peformed a test and run the `builder.sh` script with no parameters:

```shellsession
root@ubuntu-jammy:/home/vagrant/wazuh-installation-assistant# ./builder.sh 

NAME
        builder.sh - Builds the Wazuh installation assistant and tools.

SYNOPSIS
        builder.sh [-v] -i | -c | -p

DESCRIPTION
        -i,  --installer
                Builds the unattended installer single file wazuh-install.sh

        -c,  --cert-tool
                Builds the certificate creation tool wazuh-cert-tool.sh

        -p,  --password-tool
                Builds the password creation and modification tool wazuh-password-tool.sh

        -h,  --help
                Shows help.
```