### PR TITLE
Migrated documentation templates to wazuh-installation-assistant repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ wazuh-install.sh
 wazuh-passwords-tool.sh
 wazuh-certs-tool.sh
 config.yml
+!documentation-templates/wazuh/config.yml
 wazuh-install-files.tar
 wazuh-install-files/
 wazuh-offline.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [4.10.0]
 
+### Added
+
+- Migrated documentation templates to wazuh-installation-assistant repository. ([#144](https://github.com/wazuh/wazuh-installation-assistant/pull/144))
+
 ### Changed
 
 - Removed check functions for Wazuh manager and Filebeat. ([#138](https://github.com/wazuh/wazuh-installation-assistant/pull/138))

--- a/documentation-templates/wazuh/config.yml
+++ b/documentation-templates/wazuh/config.yml
@@ -1,0 +1,28 @@
+nodes:
+  # Wazuh indexer nodes
+  indexer:
+    - name: node-1
+      ip: "<indexer-node-ip>"
+    #- name: node-2
+    #  ip: "<indexer-node-ip>"
+    #- name: node-3
+    #  ip: "<indexer-node-ip>"
+
+  # Wazuh server nodes
+  # If there is more than one Wazuh server
+  # node, each one must have a node_type
+  server:
+    - name: wazuh-1
+      ip: "<wazuh-manager-ip>"
+    #  node_type: master
+    #- name: wazuh-2
+    #  ip: "<wazuh-manager-ip>"
+    #  node_type: worker
+    #- name: wazuh-3
+    #  ip: "<wazuh-manager-ip>"
+    #  node_type: worker
+
+  # Wazuh dashboard nodes
+  dashboard:
+    - name: dashboard
+      ip: "<dashboard-node-ip>"

--- a/documentation-templates/wazuh/filebeat/filebeat.yml
+++ b/documentation-templates/wazuh/filebeat/filebeat.yml
@@ -1,0 +1,39 @@
+# Wazuh - Filebeat configuration file
+output.elasticsearch:
+  hosts: ["127.0.0.1:9200"]
+  protocol: https
+  username: ${username}
+  password: ${password}
+  ssl.certificate_authorities:
+    - /etc/filebeat/certs/root-ca.pem
+  ssl.certificate: "/etc/filebeat/certs/filebeat.pem"
+  ssl.key: "/etc/filebeat/certs/filebeat-key.pem"
+setup.template.json.enabled: true
+setup.template.json.path: '/etc/filebeat/wazuh-template.json'
+setup.template.json.name: 'wazuh'
+setup.ilm.overwrite: true
+setup.ilm.enabled: false
+
+filebeat.modules:
+  - module: wazuh
+    alerts:
+      enabled: true
+    archives:
+      enabled: false
+
+logging.level: info
+logging.to_files: true
+logging.files:
+  path: /var/log/filebeat
+  name: filebeat
+  keepfiles: 7
+  permissions: 0644
+
+logging.metrics.enabled: false
+
+seccomp:
+  default_action: allow
+  syscalls:
+  - action: allow
+    names:
+    - rseq


### PR DESCRIPTION
close https://github.com/wazuh/internal-devel-requests/issues/1785

## Description

For maintenance reasons, the filebeat.yml and config.yml files used in the Wazuh documentation are migrated to be published from the wazuh-installation-assistant repository.