### PR TITLE
Solve confict in installVariables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Solve confict in installVariables ([#149](https://github.com/wazuh/wazuh-installation-assistant/pull/149))
 - Print getHelp output when no parameter is passed to the builder script. ([#142](https://github.com/wazuh/wazuh-installation-assistant/pull/142))
 
 ### Deleted

--- a/install_functions/installCommon.sh
+++ b/install_functions/installCommon.sh
@@ -743,7 +743,6 @@ function installCommon_scanDependencies() {
     # Delete duplicates and sort
     all_deps+=( "${assistant_deps[@]}" )
     all_deps=( $(echo "${all_deps[@]}" | tr ' ' '\n' | sort -u) )
-    assistant_deps_to_install=()
     deps_to_install=()
 
     # Get not installed dependencies of Assistant and Wazuh

--- a/install_functions/installVariables.sh
+++ b/install_functions/installVariables.sh
@@ -71,9 +71,4 @@ readonly indexer_yum_dependencies=( coreutils )
 readonly indexer_apt_dependencies=( debconf adduser procps gnupg apt-transport-https )
 readonly dashboard_yum_dependencies=( libcap )
 readonly dashboard_apt_dependencies=( debhelper tar curl libcap2-bin gnupg apt-transport-https )
-<<<<<<< HEAD
 readonly wia_offline_dependencies=( curl tar gnupg openssl lsof )
-wia_dependencies_installed=()
-=======
-assistant_deps_to_install=()
->>>>>>> b2f4e7a0928581ea3ce69f46a7a101bcba2fc708

--- a/install_functions/installVariables.sh
+++ b/install_functions/installVariables.sh
@@ -72,3 +72,4 @@ readonly indexer_apt_dependencies=( debconf adduser procps gnupg apt-transport-h
 readonly dashboard_yum_dependencies=( libcap )
 readonly dashboard_apt_dependencies=( debhelper tar curl libcap2-bin gnupg apt-transport-https )
 readonly wia_offline_dependencies=( curl tar gnupg openssl lsof )
+assistant_deps_to_install=()


### PR DESCRIPTION
# Description

This PR removes the conflict comment in installVariables.sh along with two variables that are not used during the Wazuh installation process.

## Related issue

- #148 