### PR TITLE
Update `upload` and `download` artifact actions to v4

### DIFF
--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build wazuh-install script and use staging packages
         run: bash builder.sh -i
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: script
           path: ./wazuh-install.sh
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: script
 
@@ -61,7 +61,7 @@ jobs:
         with:
           ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: script
 

--- a/.github/workflows/password-tool.yml
+++ b/.github/workflows/password-tool.yml
@@ -2,7 +2,6 @@ on:
   pull_request:
     paths:
       - 'passwords_tool/**'
-  workflow_dispatch:
 
 jobs:
   Build-password-tool-and-wazuh-install-scripts:

--- a/.github/workflows/password-tool.yml
+++ b/.github/workflows/password-tool.yml
@@ -2,6 +2,7 @@ on:
   pull_request:
     paths:
       - 'passwords_tool/**'
+  workflow_dispatch:
 
 jobs:
   Build-password-tool-and-wazuh-install-scripts:

--- a/.github/workflows/password-tool.yml
+++ b/.github/workflows/password-tool.yml
@@ -13,7 +13,7 @@ jobs:
           bash builder.sh -p
           bash builder.sh -i -d staging
         shell: bash
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: scripts
           path: |
@@ -26,7 +26,7 @@ jobs:
     needs: Build-password-tool-and-wazuh-install-scripts
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: scripts
       - name: Install wazuh
@@ -42,7 +42,7 @@ jobs:
     needs: Build-password-tool-and-wazuh-install-scripts
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: scripts
       - name: Install wazuh

--- a/passwords_tool/passwordsFunctions.sh
+++ b/passwords_tool/passwordsFunctions.sh
@@ -5,7 +5,7 @@
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
-
+ 
 function passwords_changePassword() {
 
     if [ -n "${changeall}" ]; then


### PR DESCRIPTION
# Description

This PR aims to update the different actions used in the installation assistant workflows from v3 to v4.

The actions updated were:
- `actions/upload-artifact`
- `actions/download-artifact`

## Related issue

- #159 