### PR TITLE
Add repository option in offline-installation workflow

### DIFF
--- a/.github/actions/offline-installation/common.sh
+++ b/.github/actions/offline-installation/common.sh
@@ -98,7 +98,7 @@ function dashboard_installation() {
 function download_resources() {
 
     check_file "${ABSOLUTE_PATH}"/wazuh-install.sh
-    bash "${ABSOLUTE_PATH}"/wazuh-install.sh -dw "${sys_type}"
+    bash "${ABSOLUTE_PATH}"/wazuh-install.sh -dw "${sys_type}" -d "${1}"
     echo "INFO: Downloading the resources..."
 
     curl -sO https://packages.wazuh.com/4.10/config.yml

--- a/.github/actions/offline-installation/common.sh
+++ b/.github/actions/offline-installation/common.sh
@@ -41,23 +41,6 @@ function check_file() {
 
 }
 
-function check_shards() {
-
-    retries=0
-    until [ "$(curl -s -k -u admin:admin "https://127.0.0.1:9200/_template/wazuh?pretty&filter_path=wazuh.settings.index.number_of_shards" | grep "number_of_shards")" ] || [ "${retries}" -eq 5 ]; do
-        sleep 5
-        retries=$((retries+1))
-    done
-
-    if [ ${retries} -eq 5 ]; then
-        echo "ERROR: Could not get the number of shards."
-        exit 1
-    fi
-    curl -s -k -u admin:admin "https://127.0.0.1:9200/_template/wazuh?pretty&filter_path=wazuh.settings.index.number_of_shards"
-    echo "INFO: Number of shards detected."
-
-}
-
 function dashboard_installation() {
 
     install_package "wazuh-dashboard"
@@ -101,14 +84,14 @@ function download_resources() {
     bash "${ABSOLUTE_PATH}"/wazuh-install.sh -dw "${sys_type}" -d "${1}"
     echo "INFO: Downloading the resources..."
 
-    curl -sO https://packages.wazuh.com/4.10/config.yml
+    curl -sO https://packages-dev.wazuh.com/${2}/config.yml
     check_file "config.yml"
 
     sed -i -e '0,/<indexer-node-ip>/ s/<indexer-node-ip>/127.0.0.1/' config.yml
     sed -i -e '0,/<wazuh-manager-ip>/ s/<wazuh-manager-ip>/127.0.0.1/' config.yml
     sed -i -e '0,/<dashboard-node-ip>/ s/<dashboard-node-ip>/127.0.0.1/' config.yml
 
-    curl -sO https://packages.wazuh.com/4.10/wazuh-certs-tool.sh
+    curl -sO https://packages-dev.wazuh.com/${2}/wazuh-certs-tool.sh
     check_file "wazuh-certs-tool.sh"
     chmod 744 wazuh-certs-tool.sh
     ./wazuh-certs-tool.sh --all
@@ -175,7 +158,6 @@ function filebeat_installation() {
     fi
 
     sleep 10
-    check_shards
     eval "filebeat test output"
     if [ "${PIPESTATUS[0]}" != 0 ]; then
         echo "ERROR: The Filebeat installation has failed."
@@ -185,9 +167,10 @@ function filebeat_installation() {
 }
 
 function indexer_initialize() {
+    /usr/share/wazuh-indexer/bin/indexer-security-init.sh
 
     retries=0
-    until [ "$(cat /var/log/wazuh-indexer/wazuh-cluster.log | grep "Node started")" ] || [ "${retries}" -eq 5 ]; do
+    while ! grep -E "\[node-[0-9]+\] Node 'node-[0-9]+' initialized" /var/log/wazuh-indexer/wazuh-cluster.log && [ "${retries}" -lt 5 ]; do
         sleep 5
         retries=$((retries+1))
     done
@@ -196,7 +179,6 @@ function indexer_initialize() {
         echo "ERROR: The indexer node is not started."
         exit 1
     fi
-    /usr/share/wazuh-indexer/bin/indexer-security-init.sh
 
 }
 

--- a/.github/actions/offline-installation/offline-installation.sh
+++ b/.github/actions/offline-installation/offline-installation.sh
@@ -6,7 +6,7 @@ ABSOLUTE_PATH="$( cd $(dirname ${0}) ; pwd -P )"
 
 check_system
 install_dependencies
-download_resources $1
+download_resources $1 $2
 
 indexer_installation
 echo "INFO: Wazuh indexer installation completed."

--- a/.github/actions/offline-installation/offline-installation.sh
+++ b/.github/actions/offline-installation/offline-installation.sh
@@ -6,7 +6,7 @@ ABSOLUTE_PATH="$( cd $(dirname ${0}) ; pwd -P )"
 
 check_system
 install_dependencies
-download_resources
+download_resources $1
 
 indexer_installation
 echo "INFO: Wazuh indexer installation completed."

--- a/.github/workflows/ansible-playbooks/offline_installation.yml
+++ b/.github/workflows/ansible-playbooks/offline_installation.yml
@@ -1,0 +1,26 @@
+---
+
+- hosts: all
+  become: true
+
+  vars:
+    script_path: "{{ tmp_path }}"
+    pkg_repository: "{{ pkg_repository }}"
+    wazuh_version: "{{ wazuh_version }}"
+    script_name: "wazuh-install.sh"
+    offline_installation_path: ".github/actions/offline-installation"
+    offline_installation_script: "offline-installation.sh"
+
+  tasks:
+    - name: Copy installation script to the offline installation directory
+      command: "cp {{ script_name }} {{ offline_installation_path }}"
+      args:
+        chdir: "{{ script_path }}"
+
+    - name: Test offline installation
+      command: "bash {{ offline_installation_script }} {{ pkg_repository }} {{ wazuh_version }}"
+      args:
+        chdir: "{{ script_path }}/{{ offline_installation_path }}"
+      register: install_results
+      async: 500
+      poll: 5

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -10,7 +10,11 @@ on:
         description: "Branch or tag of the wazuh-installation-assistant repository."
         required: true
         default: 4.10.2
-      REPOSITORY:
+      AUTOMATION_REFERENCE:
+        description: 'Branch or tag of the wazuh-automation repository'
+        required: true
+        default: '4.10.2'
+      PKG_REPOSITORY:
         description: "Repository to use for the installation."
         type: choice
         options:
@@ -18,67 +22,189 @@ on:
           - "staging"
         required: true
         default: "pre-release"
+      SYSTEMS:
+        description: "Operating Systems (list of comma-separated quoted strings enclosed in square brackets)."
+        required: true
+        default: '["Ubuntu_22", "CentOS_8"]'
+        type: string
+      VERBOSITY:
+        description: 'Verbosity level on playbooks execution'
+        required: true
+        default: '-v'
+        type: choice
+        options:
+          - -v
+          - -vv
+          - -vvv
+          - -vvvv
+      DESTROY:
+        description: 'Destroy instances after run'
+        required: true
+        default: true
+        type: boolean
 
 env:
+  WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.head_ref || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+  AUTOMATION_REFERENCE: ${{ github.event_name == 'pull_request' && '4.10.2' || inputs.AUTOMATION_REFERENCE }}
   WAZUH_VERSION: "4.10"
-  REPOSITORY: ${{ github.event_name == 'pull_request' && 'pre-release' || inputs.REPOSITORY }}
+  PKG_REPOSITORY: ${{ github.event_name == 'pull_request' && 'pre-release' || inputs.PKG_REPOSITORY }}
+  AWS_ACCOUNT: "wazuh-dev"
+  VERBOSITY: ${{ github.event_name == 'pull_request' && '-v' || inputs.VERBOSITY }}
+  COMPOSITE_NAME: "linux-SUBNAME-amd64"
+  REGION: "us-east-1"
+  TMP_PATH: "/tmp/test"
+  REPOSITORY_URL: "${{ github.server_url }}/${{ github.repository }}.git"
+  ALLOCATOR_PATH: "/tmp/allocator_instance"
+  ANSIBLE_CALLBACK: "yaml"
 
 jobs:
-  Build-wazuh-install-script:
+  Create-allocator-instances:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        system: ${{ github.event_name == 'pull_request' && fromJson('["Ubuntu_22", "CentOS_8"]') || fromJson(inputs.SYSTEMS) }}
+
     steps:
-      - name: Cancel previous runs
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          cancel_others: 'true'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          skip_after_successful_duplicate: 'false'
+    - name: View parameters
+      run: echo "${{ toJson(inputs) }}"
 
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ env.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
 
-      - name: Build wazuh-install script and use staging packages
-        run: bash builder.sh -i
+    - name: Set COMPOSITE_NAME variable
+      run: |
+        case "${{ matrix.system }}" in
+          "CentOS_7")
+            SUBNAME="centos-7"
+            ;;
+          "CentOS_8")
+            SUBNAME="centos-8"
+            ;;
+          "AmazonLinux_2")
+            SUBNAME="amazon-2"
+            ;;
+          "Ubuntu_16")
+            SUBNAME="ubuntu-16.04"
+            ;;
+          "Ubuntu_18")
+            SUBNAME="ubuntu-18.04"
+            ;;
+          "Ubuntu_20")
+            SUBNAME="ubuntu-20.04"
+            ;;
+          "Ubuntu_22")
+            SUBNAME="ubuntu-22.04"
+            ;;
+          "RHEL7")
+            SUBNAME="redhat-7"
+            ;;
+          "RHEL8")
+            SUBNAME="redhat-8"
+            ;;
+          *)
+            echo "Invalid SYSTEM selection" >&2
+            exit 1
+            ;;
+        esac
+        COMPOSITE_NAME="${COMPOSITE_NAME/SUBNAME/$SUBNAME}"
+        echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
+      
+    - &install_python_and_venv
+      name: Install python and create virtual environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3 python3-venv
+        python3 -m venv testing_venv
+        source testing_venv/bin/activate
+        python3 -m pip install --upgrade pip
+        echo PATH=$PATH >> $GITHUB_ENV
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: script
-          path: ./wazuh-install.sh
-          if-no-files-found: error
+    - name: Install Ansible
+      run: pip install ansible-core==2.16
 
-  Test-offline-installation-debian:
+    - name: Set up AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+        aws-region: ${{ env.REGION }}
+
+    - name: Checkout wazuh/wazuh-automation repository
+      uses: actions/checkout@v4
+      with:
+        repository: wazuh/wazuh-automation
+        ref: ${{ env.AUTOMATION_REFERENCE }}
+        token: ${{ secrets.GH_CLONE_TOKEN }}
+        path: wazuh-automation
+
+    - name: Install and set allocator requirements
+      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
+
+    - name: Allocate test instance and set SSH variables
+      id: allocator_instance
+      run: |
+        python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir $ALLOCATOR_PATH \
+          --track-output $ALLOCATOR_PATH/track.yml --inventory-output $ALLOCATOR_PATH/inventory.yml --instance-name gha_${{ github.run_id }}_assistant_test \
+          --label-team devops --label-termination-date 1d --aws-account ${{ env.AWS_ACCOUNT }}
+
+        sed 's/: */=/g' $ALLOCATOR_PATH/inventory.yml > $ALLOCATOR_PATH/inventory_mod.yml
+        sed -i 's/-o StrictHostKeyChecking=no/\"-o StrictHostKeyChecking=no\"/g' $ALLOCATOR_PATH/inventory_mod.yml
+        source $ALLOCATOR_PATH/inventory_mod.yml
+
+        echo "[gha_instance]" > $ALLOCATOR_PATH/inventory-${{ matrix.system }}
+        echo "$ansible_host ansible_port=$ansible_port ansible_user=$ansible_user ansible_ssh_private_key_file=$ansible_ssh_private_key_file ansible_ssh_common_args='$ansible_ssh_common_args'" >> $ALLOCATOR_PATH/inventory-${{ matrix.system }}
+    
+    - name: Upload ansible inventory
+      uses: actions/upload-artifact@v4
+      with:
+        name: inventory-${{ matrix.system }}
+        path: $ALLOCATOR_PATH/inventory-${{ matrix.system }}
+        if-no-files-found: error
+
+  Test-offline-installation:
     runs-on: ubuntu-latest
-    needs: Build-wazuh-install-script
+    needs: Create-allocator-instances
+    strategy:
+      fail-fast: false
+      matrix:
+        system: ${{ github.event_name == 'pull_request' && fromJson('["Ubuntu_22", "CentOS_8"]') || fromJson(inputs.SYSTEMS) }}
+
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+    - name: Get system inventory
+      uses: actions/download-artifact@v4
+      with:
+        name: inventory-${{ matrix.system }}
+    
+    - *install_python_and_venv
+  
+    - name: Install Ansible
+      run: pip install ansible-core==2.16
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: script
+    - name: Execute provision playbook
+      run: |
+        INSTALL_DEPS=true
+        INSTALL_PYTHON=true
+        INSTALL_PIP_DEPS=true
 
-      - name: Move installation assistant script
-        run: cp $GITHUB_WORKSPACE/wazuh-install.sh $GITHUB_WORKSPACE/.github/actions/offline-installation/wazuh-install.sh
+        ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/provision.yml \
+        -i $ALLOCATOR_PATH/inventory \
+        -l all \
+        -e "repository=$REPOSITORY_URL" \
+        -e "reference=$WAZUH_INSTALLATION_ASSISTANT_REFERENCE" \
+        -e "tmp_path=$TMP_PATH" \
+        -e "install_deps=$INSTALL_DEPS" \
+        -e "install_python=$INSTALL_PYTHON" \
+        -e "install_pip_deps=$INSTALL_PIP_DEPS" \
+        "$VERBOSITY"
 
-      - name: Run script
-        run: sudo bash $GITHUB_WORKSPACE/.github/actions/offline-installation/offline-installation.sh ${{ env.REPOSITORY}} ${{ env.WAZUH_VERSION }}
-
-  Test-offline-installation-rpm:
-    runs-on: ubuntu-latest
-    needs: Build-wazuh-install-script
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: script
-
-      - name: Move installation assistant script
-        run: cp $GITHUB_WORKSPACE/wazuh-install.sh $GITHUB_WORKSPACE/.github/actions/offline-installation/wazuh-install.sh
-
-      - name: Launch docker and run script
-        run: sudo docker run -v $GITHUB_WORKSPACE/.github/actions/offline-installation/:/tests centos:centos7 bash /tests/offline-installation.sh
+    - name: Execute offline installation playbook
+      run: |
+        ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/offline_installation.yml \
+        -i $ALLOCATOR_PATH/inventory-${{ matrix.system }} \
+        -l all \
+        -e "tmp_path=$TMP_PATH" \
+        -e "pkg_repository=$PKG_REPOSITORY" \
+        -e "wazuh_version=$WAZUH_VERSION" \
+        "$VERBOSITY"

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -20,7 +20,7 @@ on:
         default: "pre-release"
 
 env:
-  WAZUH_VERSION: 4.10
+  WAZUH_VERSION: "4.10"
   REPOSITORY: ${{ github.event_name == 'pull_request' && 'pre-release' || inputs.REPOSITORY }}
 
 jobs:

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -23,26 +23,6 @@ on:
         options:
           - staging
           - pre-release
-      SYSTEMS:
-        description: "Operating Systems (list of comma-separated quoted strings enclosed in square brackets)."
-        required: true
-        default: '["Ubuntu_22", "CentOS_8"]'
-        type: string
-      VERBOSITY:
-        description: 'Verbosity level on playbooks execution'
-        required: true
-        default: '-v'
-        type: choice
-        options:
-          - -v
-          - -vv
-          - -vvv
-          - -vvvv
-      DESTROY:
-        description: 'Destroy instances after run'
-        required: true
-        default: true
-        type: boolean
 
 env:
   WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.head_ref || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -37,11 +37,6 @@ on:
           - -vv
           - -vvv
           - -vvvv
-      DESTROY:
-        description: 'Destroy instances after run'
-        required: true
-        default: true
-        type: boolean
 
 env:
   WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.head_ref || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -15,7 +15,7 @@ on:
         type: choice
         options:
           - "pre-release"
-          - "stable"
+          - "staging"
         required: true
         default: "pre-release"
 

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -15,13 +15,13 @@ on:
         required: true
         default: '4.10.2'
       PKG_REPOSITORY:
-        description: "Repository to use for the installation."
+        description: 'Repository environment'
+        required: true
+        default: 'pre-release'
         type: choice
         options:
-          - "pre-release"
-          - "staging"
-        required: true
-        default: "pre-release"
+          - staging
+          - pre-release
       SYSTEMS:
         description: "Operating Systems (list of comma-separated quoted strings enclosed in square brackets)."
         required: true

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -20,6 +20,7 @@ on:
         default: "pre-release"
 
 env:
+  WAZUH_VERSION: 4.10
   REPOSITORY: ${{ github.event_name == 'pull_request' && 'pre-release' || inputs.REPOSITORY }}
 
 jobs:
@@ -62,7 +63,7 @@ jobs:
         run: cp $GITHUB_WORKSPACE/wazuh-install.sh $GITHUB_WORKSPACE/.github/actions/offline-installation/wazuh-install.sh
 
       - name: Run script
-        run: sudo bash $GITHUB_WORKSPACE/.github/actions/offline-installation/offline-installation.sh ${{ env.REPOSITORY}}
+        run: sudo bash $GITHUB_WORKSPACE/.github/actions/offline-installation/offline-installation.sh ${{ env.REPOSITORY}} ${{ env.WAZUH_VERSION }}
 
   Test-offline-installation-rpm:
     runs-on: ubuntu-latest

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -10,6 +10,17 @@ on:
         description: "Branch or tag of the wazuh-installation-assistant repository."
         required: true
         default: 4.10.2
+      REPOSITORY:
+        description: "Repository to use for the installation."
+        type: choice
+        options:
+          - "pre-release"
+          - "stable"
+        required: true
+        default: "pre-release"
+
+env:
+  REPOSITORY: ${{ github.event_name == 'pull_request' && 'pre-release' || inputs.REPOSITORY }}
 
 jobs:
   Build-wazuh-install-script:
@@ -51,7 +62,7 @@ jobs:
         run: cp $GITHUB_WORKSPACE/wazuh-install.sh $GITHUB_WORKSPACE/.github/actions/offline-installation/wazuh-install.sh
 
       - name: Run script
-        run: sudo bash $GITHUB_WORKSPACE/.github/actions/offline-installation/offline-installation.sh
+        run: sudo bash $GITHUB_WORKSPACE/.github/actions/offline-installation/offline-installation.sh ${{ env.REPOSITORY}}
 
   Test-offline-installation-rpm:
     runs-on: ubuntu-latest

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -1,4 +1,5 @@
 name: Offline installation test
+
 on:
   pull_request:
     paths:
@@ -9,7 +10,7 @@ on:
       WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
         description: "Branch or tag of the wazuh-installation-assistant repository."
         required: true
-        default: 4.10.2
+        default: '4.10.2'
       AUTOMATION_REFERENCE:
         description: 'Branch or tag of the wazuh-automation repository'
         required: true
@@ -37,6 +38,11 @@ on:
           - -vv
           - -vvv
           - -vvvv
+      DESTROY:
+        description: 'Destroy instances after run'
+        required: true
+        default: true
+        type: boolean
 
 env:
   WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.head_ref || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -6,23 +6,6 @@ on:
       - 'install_functions/wazuh-offline-download.sh'
       - 'install_functions/wazuh-offline-installation.sh'
   workflow_dispatch:
-    inputs:
-      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
-        description: "Branch or tag of the wazuh-installation-assistant repository."
-        required: true
-        default: '4.10.2'
-      AUTOMATION_REFERENCE:
-        description: 'Branch or tag of the wazuh-automation repository'
-        required: true
-        default: '4.10.2'
-      PKG_REPOSITORY:
-        description: 'Repository environment'
-        required: true
-        default: 'pre-release'
-        type: choice
-        options:
-          - staging
-          - pre-release
 
 env:
   WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.head_ref || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Add repository choise in offline-installation workflow ([#166](https://github.com/wazuh/wazuh-installation-assistant/pull/166))
 
 ### Deleted
 

--- a/builder.sh
+++ b/builder.sh
@@ -16,7 +16,7 @@ readonly resources_certs="${base_path_builder}/cert_tool"
 readonly resources_passwords="${base_path_builder}/passwords_tool"
 readonly resources_common="${base_path_builder}/common_functions"
 readonly resources_download="${base_path_builder}/downloader"
-source_branch="v4.10.0"
+source_branch="v4.9.2"
 
 function getHelp() {
 

--- a/builder.sh
+++ b/builder.sh
@@ -16,7 +16,7 @@ readonly resources_certs="${base_path_builder}/cert_tool"
 readonly resources_passwords="${base_path_builder}/passwords_tool"
 readonly resources_common="${base_path_builder}/common_functions"
 readonly resources_download="${base_path_builder}/downloader"
-source_branch="v4.9.2"
+source_branch="v4.10.0-rc2"
 
 function getHelp() {
 

--- a/builder.sh
+++ b/builder.sh
@@ -16,7 +16,7 @@ readonly resources_certs="${base_path_builder}/cert_tool"
 readonly resources_passwords="${base_path_builder}/passwords_tool"
 readonly resources_common="${base_path_builder}/common_functions"
 readonly resources_download="${base_path_builder}/downloader"
-source_branch="v4.10.2"
+source_branch="v4.10.0"
 
 function getHelp() {
 

--- a/install_functions/installVariables.sh
+++ b/install_functions/installVariables.sh
@@ -8,7 +8,7 @@
 
 ## Package vars
 readonly wazuh_major="4.10"
-readonly wazuh_version="4.10.2"
+readonly wazuh_version="4.10.0"
 readonly filebeat_version="7.10.2"
 readonly wazuh_install_vesion="0.1"
 source_branch="v${wazuh_version}"

--- a/install_functions/installVariables.sh
+++ b/install_functions/installVariables.sh
@@ -8,7 +8,7 @@
 
 ## Package vars
 readonly wazuh_major="4.10"
-readonly wazuh_version="4.10.0"
+readonly wazuh_version="4.9.2"
 readonly filebeat_version="7.10.2"
 readonly wazuh_install_vesion="0.1"
 source_branch="v${wazuh_version}"

--- a/install_functions/installVariables.sh
+++ b/install_functions/installVariables.sh
@@ -8,10 +8,10 @@
 
 ## Package vars
 readonly wazuh_major="4.10"
-readonly wazuh_version="4.9.2"
+readonly wazuh_version="4.10.0"
 readonly filebeat_version="7.10.2"
 readonly wazuh_install_vesion="0.1"
-source_branch="v${wazuh_version}"
+source_branch="v${wazuh_version}-rc2"
 
 repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"
 repobaseurl="https://packages.wazuh.com/4.x"

--- a/install_functions/wazuh-offline-download.sh
+++ b/install_functions/wazuh-offline-download.sh
@@ -7,7 +7,7 @@
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
- 
+
 function offline_download() {
 
   common_logger "Starting Wazuh packages download."

--- a/install_functions/wazuh-offline-download.sh
+++ b/install_functions/wazuh-offline-download.sh
@@ -7,7 +7,7 @@
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
-
+ 
 function offline_download() {
 
   common_logger "Starting Wazuh packages download."


### PR DESCRIPTION
# Description

The purpose of this PR is to add the `-d` option when generating packages in the Wazuh offline installation workflow. Also a new input has been added in the workflow_dispatch so that you can manually switch between staging or pre-release.

>[!WARNING]
> If enabled by a PR, it uses 'pre-release' by default.