### PR TITLE
Update `-d` option in the password tool workflow and fix test scripts

### DIFF
--- a/.github/actions/passwords-tool/tests-stack-failure.sh
+++ b/.github/actions/passwords-tool/tests-stack-failure.sh
@@ -13,8 +13,8 @@ elif ! curl -s -u wazuh:wazuh -k -X POST "https://127.0.0.1:55000/security/user/
    exit 1
 elif ! curl -s -u wazuuh:"${apiPass}" -k -X POST "https://127.0.0.1:55000/security/user/authenticate" | grep "Invalid credentials"; then
    exit 1
-elif ! curl -s -XGET https://127.0.0.1:9200/ -u admin:admin -k | grep "Unauthorized"; then
+elif ! curl -s -XGET https://127.0.0.1:9200/ -u admin:admin -k -w %{http_code} | grep "401"; then
    exit 1
-elif ! curl -s -XGET https://127.0.0.1:9200/ -u adminnnn:"${adminPass}" -k | grep "Unauthorized"; then
+elif ! curl -s -XGET https://127.0.0.1:9200/ -u adminnnn:"${adminPass}" -k -w %{http_code} | grep "401"; then
    exit 1
 fi

--- a/.github/actions/passwords-tool/tests-stack-success.sh
+++ b/.github/actions/passwords-tool/tests-stack-success.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-users=( admin kibanaserver kibanaro logstash readall snapshotrestore )
+users=( admin anomalyadmin kibanaserver kibanaro logstash readall snapshotrestore )
 api_users=( wazuh wazuh-wui )
 
 echo '::group:: Change indexer password, password providing it.'
@@ -35,8 +35,9 @@ echo '::group:: Change all passwords.'
 
 wazuh_pass="$(cat wazuh-install-files/wazuh-passwords.txt | awk "/username: 'wazuh'/{getline;print;}" | awk '{ print $2 }' | tr -d \' )"
 
-mapfile -t passall < <(bash wazuh-passwords-tool.sh -a -au wazuh -ap "${wazuh_pass}" | grep 'The password for' | awk '{ print $NF }' ) 
-passindexer=("${passall[@]:0:6}")
+mapfile -t passall < <(bash wazuh-passwords-tool.sh -a -A -au wazuh -ap "${wazuh_pass}" | grep 'The password for' | awk '{ print $NF }' )
+
+passindexer=("${passall[@]:0:7}")
 passapi=("${passall[@]:(-2)}")
 
 for i in "${!users[@]}"; do
@@ -55,7 +56,7 @@ echo '::endgroup::'
 
 echo '::group:: Change single Wazuh API user.'
 
-bash wazuh-passwords-tool.sh -au wazuh -ap "${passapi[0]}" -u wazuh -p BkJt92r*ndzN.CkCYWn?d7i5Z7EaUt63 -A 
+bash wazuh-passwords-tool.sh -A -au wazuh -ap "${passapi[0]}" -u wazuh -p BkJt92r*ndzN.CkCYWn?d7i5Z7EaUt63
     if curl -s -w "%{http_code}" -u wazuh:BkJt92r*ndzN.CkCYWn?d7i5Z7EaUt63 -k -X POST "https://127.0.0.1:55000/security/user/authenticate" | grep "401"; then
         exit 1
     fi
@@ -72,8 +73,8 @@ done
 echo '::endgroup::'
 
 echo '::group:: Change all passwords from a file.'
-mapfile -t passallf < <(bash wazuh-passwords-tool.sh -f wazuh-install-files/wazuh-passwords.txt -au wazuh -ap BkJt92r*ndzN.CkCYWn?d7i5Z7EaUt63 | grep 'The password for' | awk '{ print $NF }' )
-passindexerf=("${passallf[@]:0:6}")
+mapfile -t passallf < <(bash wazuh-passwords-tool.sh -f wazuh-install-files/wazuh-passwords.txt -A -au wazuh -ap BkJt92r*ndzN.CkCYWn?d7i5Z7EaUt63 | grep 'The password for' | awk '{ print $NF }' )
+passindexerf=("${passallf[@]:0:7}")
 passapif=("${passallf[@]:(-2)}")
 
 for i in "${!users[@]}"; do

--- a/.github/workflows/password-tool.yml
+++ b/.github/workflows/password-tool.yml
@@ -2,6 +2,23 @@ on:
   pull_request:
     paths:
       - 'passwords_tool/**'
+  workflow_dispatch:
+    inputs:
+      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
+        description: "Branch or tag of the wazuh-installation-assistant repository."
+        required: true
+        default: 4.10.2
+      REPOSITORY:
+        description: "Repository to use for the installation."
+        type: choice
+        options:
+          - "pre-release"
+          - "staging"
+        required: true
+        default: "pre-release"
+
+env:
+  REPOSITORY: ${{ github.event_name == 'pull_request' && 'pre-release' || inputs.REPOSITORY }}
 
 jobs:
   Build-password-tool-and-wazuh-install-scripts:
@@ -11,7 +28,7 @@ jobs:
       - name: Build password-tool and wazuh-install scripts
         run: |
           bash builder.sh -p
-          bash builder.sh -i -d staging
+          bash builder.sh -i
         shell: bash
       - uses: actions/upload-artifact@v3
         with:
@@ -31,7 +48,7 @@ jobs:
           name: scripts
       - name: Install wazuh
         run: |
-          sudo bash wazuh-install.sh -a -v
+          sudo bash wazuh-install.sh -a -v -d ${{ env.REPOSITORY }}
       - name: Uncompress wazuh install files
         run: sudo tar -xvf wazuh-install-files.tar
       - name: Run script
@@ -47,7 +64,7 @@ jobs:
           name: scripts
       - name: Install wazuh
         run: |
-          sudo bash wazuh-install.sh -a -v
+          sudo bash wazuh-install.sh -a -v -d ${{ env.REPOSITORY }}
       - name: Uncompress wazuh install files
         run: sudo tar -xvf wazuh-install-files.tar
       - name: Run script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Update `-d` option in the password tool workflow and fix test scripts ([#170](https://github.com/wazuh/wazuh-installation-assistant/pull/170))
 - Added architecture information to assistant. ([#92](https://github.com/wazuh/wazuh-installation-assistant/pull/92))
 
 ### Deleted


### PR DESCRIPTION
# Description

This PR aims to update the `-d` options in the password tool workflows as it used to be passed as an option to the builder script and now it has to be in the wazuh-install script to work properly.

Once this PR was opened, we found that the workflows were not working as expected, so we investigated and fixed the bugs in the files:

- `.github/actions/passwords-tool/tests-stack-success.sh`
- `.github/actions/passwords-tool/tests-stack-failure.sh` 

In addition, a workflow dispatch has been added in order to run it manually and make testing easier from now on.

## Testing :test_tube: 

- https://github.com/wazuh/wazuh-installation-assistant/actions/runs/12396215542/job/34603731896?pr=170
## Related issue

- #162 