### PR TITLE
Update offline installation workflows and scripts

### DIFF
--- a/.github/actions/offline-installation/common.sh
+++ b/.github/actions/offline-installation/common.sh
@@ -157,7 +157,7 @@ function filebeat_installation() {
         /usr/share/filebeat/bin/filebeat --environment systemd -c /etc/filebeat/filebeat.yml --path.home /usr/share/filebeat --path.config /etc/filebeat --path.data /var/lib/filebeat --path.logs /var/log/filebeat &
     fi
 
-    sleep 10
+    sleep 30
     eval "filebeat test output"
     if [ "${PIPESTATUS[0]}" != 0 ]; then
         echo "ERROR: The Filebeat installation has failed."

--- a/.github/actions/offline-installation/common.sh
+++ b/.github/actions/offline-installation/common.sh
@@ -41,23 +41,6 @@ function check_file() {
 
 }
 
-function check_shards() {
-
-    retries=0
-    until [ "$(curl -s -k -u admin:admin "https://127.0.0.1:9200/_template/wazuh?pretty&filter_path=wazuh.settings.index.number_of_shards" | grep "number_of_shards")" ] || [ "${retries}" -eq 5 ]; do
-        sleep 5
-        retries=$((retries+1))
-    done
-
-    if [ ${retries} -eq 5 ]; then
-        echo "ERROR: Could not get the number of shards."
-        exit 1
-    fi
-    curl -s -k -u admin:admin "https://127.0.0.1:9200/_template/wazuh?pretty&filter_path=wazuh.settings.index.number_of_shards"
-    echo "INFO: Number of shards detected."
-
-}
-
 function dashboard_installation() {
 
     install_package "wazuh-dashboard"
@@ -98,17 +81,17 @@ function dashboard_installation() {
 function download_resources() {
 
     check_file "${ABSOLUTE_PATH}"/wazuh-install.sh
-    bash "${ABSOLUTE_PATH}"/wazuh-install.sh -dw "${sys_type}"
+    bash "${ABSOLUTE_PATH}"/wazuh-install.sh -dw "${sys_type}" -d "${1}"
     echo "INFO: Downloading the resources..."
 
-    curl -sO https://packages.wazuh.com/4.11/config.yml
+    curl -sO https://packages-dev.wazuh.com/${2}/config.yml
     check_file "config.yml"
 
     sed -i -e '0,/<indexer-node-ip>/ s/<indexer-node-ip>/127.0.0.1/' config.yml
     sed -i -e '0,/<wazuh-manager-ip>/ s/<wazuh-manager-ip>/127.0.0.1/' config.yml
     sed -i -e '0,/<dashboard-node-ip>/ s/<dashboard-node-ip>/127.0.0.1/' config.yml
 
-    curl -sO https://packages.wazuh.com/4.11/wazuh-certs-tool.sh
+    curl -sO https://packages-dev.wazuh.com/${2}/wazuh-certs-tool.sh
     check_file "wazuh-certs-tool.sh"
     chmod 744 wazuh-certs-tool.sh
     ./wazuh-certs-tool.sh --all
@@ -175,7 +158,6 @@ function filebeat_installation() {
     fi
 
     sleep 10
-    check_shards
     eval "filebeat test output"
     if [ "${PIPESTATUS[0]}" != 0 ]; then
         echo "ERROR: The Filebeat installation has failed."
@@ -185,9 +167,10 @@ function filebeat_installation() {
 }
 
 function indexer_initialize() {
+    /usr/share/wazuh-indexer/bin/indexer-security-init.sh
 
     retries=0
-    until [ "$(cat /var/log/wazuh-indexer/wazuh-cluster.log | grep "Node started")" ] || [ "${retries}" -eq 5 ]; do
+    while ! grep -E "\[node-[0-9]+\] Node 'node-[0-9]+' initialized" /var/log/wazuh-indexer/wazuh-cluster.log && [ "${retries}" -lt 5 ]; do
         sleep 5
         retries=$((retries+1))
     done
@@ -196,7 +179,6 @@ function indexer_initialize() {
         echo "ERROR: The indexer node is not started."
         exit 1
     fi
-    /usr/share/wazuh-indexer/bin/indexer-security-init.sh
 
 }
 
@@ -225,7 +207,7 @@ function indexer_installation() {
 
     if [ "${sys_type}" == "rpm" ]; then
         runuser "wazuh-indexer" --shell="/bin/bash" --command="OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/bin/opensearch" > /dev/null 2>&1 &
-        sleep 5
+        sleep 20
     elif [ "${sys_type}" == "deb" ]; then
         enable_start_service "wazuh-indexer"
     fi

--- a/.github/actions/offline-installation/offline-installation.sh
+++ b/.github/actions/offline-installation/offline-installation.sh
@@ -6,7 +6,7 @@ ABSOLUTE_PATH="$( cd $(dirname ${0}) ; pwd -P )"
 
 check_system
 install_dependencies
-download_resources
+download_resources $1 $2
 
 indexer_installation
 echo "INFO: Wazuh indexer installation completed."

--- a/.github/workflows/ansible-playbooks/offline_installation.yml
+++ b/.github/workflows/ansible-playbooks/offline_installation.yml
@@ -1,0 +1,26 @@
+---
+
+- hosts: all
+  become: true
+
+  vars:
+    script_path: "{{ tmp_path }}"
+    pkg_repository: "{{ pkg_repository }}"
+    wazuh_version: "{{ wazuh_version }}"
+    script_name: "wazuh-install.sh"
+    offline_installation_path: ".github/actions/offline-installation"
+    offline_installation_script: "offline-installation.sh"
+
+  tasks:
+    - name: Copy installation script to the offline installation directory
+      command: "cp {{ script_name }} {{ offline_installation_path }}"
+      args:
+        chdir: "{{ script_path }}"
+
+    - name: Test offline installation
+      command: "bash {{ offline_installation_script }} {{ pkg_repository }} {{ wazuh_version }}"
+      args:
+        chdir: "{{ script_path }}/{{ offline_installation_path }}"
+      register: install_results
+      async: 500
+      poll: 5

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -182,7 +182,7 @@ jobs:
 
     - name: Get instance-id
       run: |
-        echo "INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=wia-161-centos-7" --output text)" >> $GITHUB_ENV
+        echo "INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)" >> $GITHUB_ENV
 
     - name: Change security group
       run: |

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -14,7 +14,7 @@ on:
       AUTOMATION_REFERENCE:
         description: 'Branch or tag of the wazuh-automation repository'
         required: true
-        default: '4.10.2'
+        default: 'v4.10.2'
       PKG_REPOSITORY:
         description: 'Repository environment'
         required: true
@@ -135,15 +135,12 @@ jobs:
         role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
         aws-region: ${{ env.REGION }}
 
-    - name: Display Deployment Report
-      if: always()
-      run: echo ${{ env.AUTOMATION_REFERENCE }}
-
     - name: Checkout wazuh/wazuh-automation repository
       uses: actions/checkout@v4
       with:
         repository: wazuh/wazuh-automation
         ref: ${{ env.AUTOMATION_REFERENCE }}
+        token: ${{ secrets.GH_CLONE_TOKEN }}
         path: wazuh-automation
 
     - name: Install and set allocator requirements

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -199,6 +199,6 @@ jobs:
         -e "wazuh_version=$WAZUH_VERSION" \
         "$VERBOSITY"
 
-    - name: Delete allocated VM
-      if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == true || github.event_name == 'pull_request')
-      run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output $ALLOCATOR_PATH/track.yml
+    #- name: Delete allocated VM
+    #  if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == true || github.event_name == 'pull_request')
+    #  run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output $ALLOCATOR_PATH/track.yml

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -182,7 +182,7 @@ jobs:
 
     - name: Get instance-id
       run: |
-        echo "INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --profile wazuh-qa --filters "Name=tag:Name,Values=wia-161-centos-7" --output text)" >> $GITHUB_ENV
+        echo "INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=wia-161-centos-7" --output text)" >> $GITHUB_ENV
 
     - name: Change security group
       run: |

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -182,7 +182,7 @@ jobs:
 
     - name: Get instance-id
       run: |
-        INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)
+        INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[0].Instances[0].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)
         echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
 
     - name: Change security group

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -58,6 +58,10 @@ env:
   ALLOCATOR_PATH: "/tmp/allocator_instance"
   ANSIBLE_CALLBACK: "yaml"
 
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
 jobs:
   Create-allocator-instances:
     runs-on: ubuntu-latest

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -156,6 +156,11 @@ jobs:
         echo "[gha_instance]" > $ALLOCATOR_PATH/inventory
         echo "$ansible_host ansible_port=$ansible_port ansible_user=$ansible_user ansible_ssh_private_key_file=$ansible_ssh_private_key_file ansible_ssh_common_args='$ansible_ssh_common_args'" >> $ALLOCATOR_PATH/inventory
 
+    - name: Get instance-id
+      run: |
+        INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[0].Instances[0].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)
+        echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
+
     - name: Install Ansible
       run: pip install ansible-core==2.16
 
@@ -179,11 +184,6 @@ jobs:
         -e "install_python=$INSTALL_PYTHON" \
         -e "install_pip_deps=$INSTALL_PIP_DEPS" \
         "$VERBOSITY"
-
-    - name: Get instance-id
-      run: |
-        INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[0].Instances[0].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)
-        echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
 
     - name: Change security group
       run: |

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -10,11 +10,11 @@ on:
       WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
         description: "Branch or tag of the wazuh-installation-assistant repository."
         required: true
-        default: 4.10.2
+        default: 4.10.1
       AUTOMATION_REFERENCE:
         description: 'Branch or tag of the wazuh-automation repository'
         required: true
-        default: 'v4.10.2'
+        default: 'v4.10.1'
       PKG_REPOSITORY:
         description: 'Repository environment'
         required: true
@@ -49,7 +49,6 @@ env:
   AUTOMATION_REFERENCE: ${{ inputs.AUTOMATION_REFERENCE }}
   WAZUH_VERSION: "4.10"
   PKG_REPOSITORY: ${{ github.event_name == 'pull_request' && 'pre-release' || inputs.PKG_REPOSITORY }}
-  #AWS_ACCOUNT: "wazuh-dev"
   VERBOSITY: ${{ github.event_name == 'pull_request' && '-v' || inputs.VERBOSITY }}
   COMPOSITE_NAME: "linux-SUBNAME-amd64"
   REGION: "us-east-1"
@@ -59,8 +58,8 @@ env:
   ANSIBLE_CALLBACK: "yaml"
 
 permissions:
-  id-token: write   # This is required for requesting the JWT
-  contents: read    # This is required for actions/checkout
+  id-token: write
+  contents: read
 
 jobs:
   Create-allocator-instances:
@@ -181,6 +180,14 @@ jobs:
         -e "install_pip_deps=$INSTALL_PIP_DEPS" \
         "$VERBOSITY"
 
+    - name: Get instance-id
+      run: |
+        echo "INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --profile wazuh-qa --filters "Name=tag:Name,Values=wia-161-centos-7" --output text)" >> $GITHUB_ENV
+
+    - name: Change security group
+      run: |
+        aws ec2 modify-instance-attribute --instance-id {{ env.INSTANCE_ID }} --groups sg-03c53339089a65829
+
     - name: Execute offline installation playbook
       run: |
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/offline_installation.yml \
@@ -190,19 +197,6 @@ jobs:
         -e "pkg_repository=$PKG_REPOSITORY" \
         -e "wazuh_version=$WAZUH_VERSION" \
         "$VERBOSITY"
-
-    - name: Compress Allocator VM directory
-      id: compress_allocator_files
-      if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == false && github.event_name != 'pull_request'
-      run: |
-        zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r $ALLOCATOR_PATH.zip $ALLOCATOR_PATH
-
-    - name: Upload Allocator VM directory as artifact
-      if: always() && steps.compress_allocator_files.outcome == 'success' && inputs.DESTROY == false && github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v4
-      with:
-        name: allocator-instance-${{ matrix.system }}
-        path: ${{ env.ALLOCATOR_PATH }}.zip
 
     - name: Delete allocated VM
       if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == true || github.event_name == 'pull_request')

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -180,9 +180,13 @@ jobs:
         -e "install_pip_deps=$INSTALL_PIP_DEPS" \
         "$VERBOSITY"
 
-    - name: Get instance-id and modify security group
+    - name: Get instance-id
       run: |
-        aws ec2 modify-instance-attribute --instance-id $(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text) --groups sg-03c53339089a65829
+        echo "INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)" >> $GITHUB_ENV
+
+    - name: Change security group
+      run: |
+        aws ec2 modify-instance-attribute --instance-id ${{ env.INSTANCE_ID }} --groups sg-03c53339089a65829
 
     - name: Execute offline installation playbook
       run: |

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -49,7 +49,7 @@ env:
   AUTOMATION_REFERENCE: ${{ github.event_name == 'pull_request' && '4.10.2' || inputs.AUTOMATION_REFERENCE }}
   WAZUH_VERSION: "4.10"
   PKG_REPOSITORY: ${{ github.event_name == 'pull_request' && 'pre-release' || inputs.PKG_REPOSITORY }}
-  AWS_ACCOUNT: "wazuh-dev"
+  #AWS_ACCOUNT: "wazuh-dev"
   VERBOSITY: ${{ github.event_name == 'pull_request' && '-v' || inputs.VERBOSITY }}
   COMPOSITE_NAME: "linux-SUBNAME-amd64"
   REGION: "us-east-1"
@@ -112,7 +112,7 @@ jobs:
         esac
         COMPOSITE_NAME="${COMPOSITE_NAME/SUBNAME/$SUBNAME}"
         echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
-      
+
     - name: Install python and create virtual environment
       run: |
         sudo apt-get update
@@ -124,13 +124,13 @@ jobs:
 
     - name: Install Ansible
       run: pip install ansible-core==2.16
-    
+
     - name: Set up AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v3
       with:
         role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
         aws-region: ${{ env.REGION }}
-    
+
     - name: Checkout wazuh/wazuh-automation repository
       uses: actions/checkout@v4
       with:
@@ -138,7 +138,7 @@ jobs:
         ref: ${{ env.AUTOMATION_REFERENCE }}
         token: ${{ secrets.GH_CLONE_TOKEN }}
         path: wazuh-automation
-    
+
     - name: Install and set allocator requirements
       run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
 
@@ -147,7 +147,7 @@ jobs:
       run: |
         python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir $ALLOCATOR_PATH \
           --track-output $ALLOCATOR_PATH/track.yml --inventory-output $ALLOCATOR_PATH/inventory.yml --instance-name gha_${{ github.run_id }}_assistant_test \
-          --label-team devops --label-termination-date 1d --aws-account ${{ env.AWS_ACCOUNT }}
+          --label-team devops --label-termination-date 1d
 
         sed 's/: */=/g' $ALLOCATOR_PATH/inventory.yml > $ALLOCATOR_PATH/inventory_mod.yml
         sed -i 's/-o StrictHostKeyChecking=no/\"-o StrictHostKeyChecking=no\"/g' $ALLOCATOR_PATH/inventory_mod.yml
@@ -182,7 +182,7 @@ jobs:
         -e "pkg_repository=$PKG_REPOSITORY" \
         -e "wazuh_version=$WAZUH_VERSION" \
         "$VERBOSITY"
-  
+
     - name: Compress Allocator VM directory
       id: compress_allocator_files
       if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == false && github.event_name != 'pull_request'

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -146,7 +146,7 @@ jobs:
       id: allocator_instance
       run: |
         python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir $ALLOCATOR_PATH \
-          --track-output $ALLOCATOR_PATH/track.yml --inventory-output $ALLOCATOR_PATH/inventory.yml --instance-name gha_${{ github.run_id }}_assistant_test \
+          --track-output $ALLOCATOR_PATH/track.yml --inventory-output $ALLOCATOR_PATH/inventory.yml --instance-name gha_${{ env.COMPOSITE_NAME }}_${{ github.run_id }}_assistant_test \
           --label-team devops --label-termination-date 1d
 
         sed 's/: */=/g' $ALLOCATOR_PATH/inventory.yml > $ALLOCATOR_PATH/inventory_mod.yml
@@ -155,11 +155,6 @@ jobs:
 
         echo "[gha_instance]" > $ALLOCATOR_PATH/inventory
         echo "$ansible_host ansible_port=$ansible_port ansible_user=$ansible_user ansible_ssh_private_key_file=$ansible_ssh_private_key_file ansible_ssh_common_args='$ansible_ssh_common_args'" >> $ALLOCATOR_PATH/inventory
-
-    - name: Get instance-id
-      run: |
-        INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[0].Instances[0].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)
-        echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
 
     - name: Install Ansible
       run: pip install ansible-core==2.16
@@ -184,6 +179,11 @@ jobs:
         -e "install_python=$INSTALL_PYTHON" \
         -e "install_pip_deps=$INSTALL_PIP_DEPS" \
         "$VERBOSITY"
+
+    - name: Get instance-id
+      run: |
+        INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[0].Instances[0].InstanceId' --filters "Name=tag:Name,Values=gha_${{ env.COMPOSITE_NAME }}_${{ github.run_id }}_assistant_test" --output text)
+        echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
 
     - name: Change security group
       run: |

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -126,9 +126,6 @@ jobs:
         python3 -m pip install --upgrade pip
         echo PATH=$PATH >> $GITHUB_ENV
 
-    - name: Install Ansible
-      run: pip install ansible-core==2.16
-
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v3
       with:
@@ -159,6 +156,13 @@ jobs:
 
         echo "[gha_instance]" > $ALLOCATOR_PATH/inventory
         echo "$ansible_host ansible_port=$ansible_port ansible_user=$ansible_user ansible_ssh_private_key_file=$ansible_ssh_private_key_file ansible_ssh_common_args='$ansible_ssh_common_args'" >> $ALLOCATOR_PATH/inventory
+
+    - name: Install Ansible
+      run: pip install ansible-core==2.16
+
+    - name: configure ansible
+      run: |
+        ansible-galaxy collection install community.general
 
     - name: Execute provision playbook
       run: |

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -38,6 +38,11 @@ on:
           - -vv
           - -vvv
           - -vvvv
+      DESTROY:
+        description: 'Destroy instances after run'
+        required: true
+        default: true
+        type: boolean
 
 env:
   WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.head_ref || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
@@ -108,8 +113,7 @@ jobs:
         COMPOSITE_NAME="${COMPOSITE_NAME/SUBNAME/$SUBNAME}"
         echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
       
-    - &install_python_and_venv
-      name: Install python and create virtual environment
+    - name: Install python and create virtual environment
       run: |
         sudo apt-get update
         sudo apt-get install -y python3 python3-venv
@@ -121,15 +125,13 @@ jobs:
     - name: Install Ansible
       run: pip install ansible-core==2.16
     
-    - &setup_aws_credentials
-      name: Set up AWS credentials
+    - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
         aws-region: ${{ env.REGION }}
     
-    - &checkout_wazuh_automation
-      name: Checkout wazuh/wazuh-automation repository
+    - name: Checkout wazuh/wazuh-automation repository
       uses: actions/checkout@v4
       with:
         repository: wazuh/wazuh-automation
@@ -137,56 +139,22 @@ jobs:
         token: ${{ secrets.GH_CLONE_TOKEN }}
         path: wazuh-automation
     
-    - &install_and_set_allocator_requirements
-      name: Install and set allocator requirements
+    - name: Install and set allocator requirements
       run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
 
     - name: Allocate test instance and set SSH variables
       id: allocator_instance
       run: |
         python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir $ALLOCATOR_PATH \
-          --track-output $ALLOCATOR_PATH/track-${{ matrix.system }}.yml --inventory-output $ALLOCATOR_PATH/inventory.yml --instance-name gha_${{ github.run_id }}_assistant_test \
+          --track-output $ALLOCATOR_PATH/track.yml --inventory-output $ALLOCATOR_PATH/inventory.yml --instance-name gha_${{ github.run_id }}_assistant_test \
           --label-team devops --label-termination-date 1d --aws-account ${{ env.AWS_ACCOUNT }}
 
         sed 's/: */=/g' $ALLOCATOR_PATH/inventory.yml > $ALLOCATOR_PATH/inventory_mod.yml
         sed -i 's/-o StrictHostKeyChecking=no/\"-o StrictHostKeyChecking=no\"/g' $ALLOCATOR_PATH/inventory_mod.yml
         source $ALLOCATOR_PATH/inventory_mod.yml
 
-        echo "[gha_instance]" > $ALLOCATOR_PATH/inventory-${{ matrix.system }}
-        echo "$ansible_host ansible_port=$ansible_port ansible_user=$ansible_user ansible_ssh_private_key_file=$ansible_ssh_private_key_file ansible_ssh_common_args='$ansible_ssh_common_args'" >> $ALLOCATOR_PATH/inventory-${{ matrix.system }}
-    
-    - name: Upload ansible inventory
-      uses: actions/upload-artifact@v4
-      with:
-        name: inventory-${{ matrix.system }}
-        path: $ALLOCATOR_PATH/inventory-${{ matrix.system }}
-        if-no-files-found: error
-
-    - name: Upload instance track
-      uses: actions/upload-artifact@v4
-      with:
-        name: track-${{ matrix.system }}
-        path: $ALLOCATOR_PATH/track-${{ matrix.system }}.yml
-        if-no-files-found: error
-
-  Test-offline-installation:
-    runs-on: ubuntu-latest
-    needs: Create-allocator-instances
-    strategy:
-      fail-fast: false
-      matrix:
-        system: ${{ github.event_name == 'pull_request' && fromJson('["Ubuntu_22", "CentOS_8"]') || fromJson(inputs.SYSTEMS) }}
-
-    steps:
-    - name: Get system inventory
-      uses: actions/download-artifact@v4
-      with:
-        name: inventory-${{ matrix.system }}
-    
-    - *install_python_and_venv
-  
-    - name: Install Ansible
-      run: pip install ansible-core==2.16
+        echo "[gha_instance]" > $ALLOCATOR_PATH/inventory
+        echo "$ansible_host ansible_port=$ansible_port ansible_user=$ansible_user ansible_ssh_private_key_file=$ansible_ssh_private_key_file ansible_ssh_common_args='$ansible_ssh_common_args'" >> $ALLOCATOR_PATH/inventory
 
     - name: Execute provision playbook
       run: |
@@ -195,7 +163,7 @@ jobs:
         INSTALL_PIP_DEPS=true
 
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/provision.yml \
-        -i inventory-${{ matrix.system }} \
+        -i $ALLOCATOR_PATH/inventory \
         -l all \
         -e "repository=$REPOSITORY_URL" \
         -e "reference=$WAZUH_INSTALLATION_ASSISTANT_REFERENCE" \
@@ -208,35 +176,26 @@ jobs:
     - name: Execute offline installation playbook
       run: |
         ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/offline_installation.yml \
-        -i inventory-${{ matrix.system }} \
+        -i $ALLOCATOR_PATH/inventory \
         -l all \
         -e "tmp_path=$TMP_PATH" \
         -e "pkg_repository=$PKG_REPOSITORY" \
         -e "wazuh_version=$WAZUH_VERSION" \
         "$VERBOSITY"
   
-  Release-instances:
-    runs-on: ubuntu-latest
-    needs: 
-      - Create-allocator-instances
-      - Test-offline-installation 
-    if: ${{ needs.Create-allocator-instances.result == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        system: ${{ github.event_name == 'pull_request' && fromJson('["Ubuntu_22", "CentOS_8"]') || fromJson(inputs.SYSTEMS) }}
+    - name: Compress Allocator VM directory
+      id: compress_allocator_files
+      if: always() && steps.allocator_instance.outcome == 'success' && inputs.DESTROY == false && github.event_name != 'pull_request'
+      run: |
+        zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r $ALLOCATOR_PATH.zip $ALLOCATOR_PATH
 
-    steps:
-    - name: Get instance track
-      uses: actions/download-artifact@v4
+    - name: Upload Allocator VM directory as artifact
+      if: always() && steps.compress_allocator_files.outcome == 'success' && inputs.DESTROY == false && github.event_name != 'pull_request'
+      uses: actions/upload-artifact@v4
       with:
-        name: track-${{ matrix.system }}.yml
-    
-    - *install_python_and_venv
+        name: allocator-instance-${{ matrix.system }}
+        path: ${{ env.ALLOCATOR_PATH }}.zip
 
-    - *checkout_wazuh_automation
-
-    - *install_and_set_allocator_requirements
-
-    - name: Release test instance
-      run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output track-${{ matrix.system }}.yml --aws-profile ${{ env.AWS_ACCOUNT }}
+    - name: Delete allocated VM
+      if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == true || github.event_name == 'pull_request')
+      run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output $ALLOCATOR_PATH/track.yml

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -1,4 +1,5 @@
 name: Offline installation test
+
 on:
   pull_request:
     paths:
@@ -9,64 +10,233 @@ on:
       WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
         description: "Branch or tag of the wazuh-installation-assistant repository."
         required: true
-        default: 4.11.0
+        default: 4.10.2
+      AUTOMATION_REFERENCE:
+        description: 'Branch or tag of the wazuh-automation repository'
+        required: true
+        default: '4.10.2'
+      PKG_REPOSITORY:
+        description: 'Repository environment'
+        required: true
+        default: 'pre-release'
+        type: choice
+        options:
+          - staging
+          - pre-release
+      SYSTEMS:
+        description: "Operating Systems (list of comma-separated quoted strings enclosed in square brackets)."
+        required: true
+        default: '["Ubuntu_22", "CentOS_8"]'
+        type: string
+      VERBOSITY:
+        description: 'Verbosity level on playbooks execution'
+        required: true
+        default: '-v'
+        type: choice
+        options:
+          - -v
+          - -vv
+          - -vvv
+          - -vvvv
+
+env:
+  WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.head_ref || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+  AUTOMATION_REFERENCE: ${{ github.event_name == 'pull_request' && '4.10.2' || inputs.AUTOMATION_REFERENCE }}
+  WAZUH_VERSION: "4.10"
+  PKG_REPOSITORY: ${{ github.event_name == 'pull_request' && 'pre-release' || inputs.PKG_REPOSITORY }}
+  AWS_ACCOUNT: "wazuh-dev"
+  VERBOSITY: ${{ github.event_name == 'pull_request' && '-v' || inputs.VERBOSITY }}
+  COMPOSITE_NAME: "linux-SUBNAME-amd64"
+  REGION: "us-east-1"
+  TMP_PATH: "/tmp/test"
+  REPOSITORY_URL: "${{ github.server_url }}/${{ github.repository }}.git"
+  ALLOCATOR_PATH: "/tmp/allocator_instance"
+  ANSIBLE_CALLBACK: "yaml"
 
 jobs:
-  Build-wazuh-install-script:
+  Create-allocator-instances:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        system: ${{ github.event_name == 'pull_request' && fromJson('["Ubuntu_22", "CentOS_8"]') || fromJson(inputs.SYSTEMS) }}
+
     steps:
-      - name: Cancel previous runs
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          cancel_others: 'true'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          skip_after_successful_duplicate: 'false'
+    - name: View parameters
+      run: echo "${{ toJson(inputs) }}"
 
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ env.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
 
-      - name: Build wazuh-install script and use staging packages
-        run: bash builder.sh -i
+    - name: Set COMPOSITE_NAME variable
+      run: |
+        case "${{ matrix.system }}" in
+          "CentOS_7")
+            SUBNAME="centos-7"
+            ;;
+          "CentOS_8")
+            SUBNAME="centos-8"
+            ;;
+          "AmazonLinux_2")
+            SUBNAME="amazon-2"
+            ;;
+          "Ubuntu_16")
+            SUBNAME="ubuntu-16.04"
+            ;;
+          "Ubuntu_18")
+            SUBNAME="ubuntu-18.04"
+            ;;
+          "Ubuntu_20")
+            SUBNAME="ubuntu-20.04"
+            ;;
+          "Ubuntu_22")
+            SUBNAME="ubuntu-22.04"
+            ;;
+          "RHEL7")
+            SUBNAME="redhat-7"
+            ;;
+          "RHEL8")
+            SUBNAME="redhat-8"
+            ;;
+          *)
+            echo "Invalid SYSTEM selection" >&2
+            exit 1
+            ;;
+        esac
+        COMPOSITE_NAME="${COMPOSITE_NAME/SUBNAME/$SUBNAME}"
+        echo "COMPOSITE_NAME=$COMPOSITE_NAME" >> $GITHUB_ENV
+      
+    - &install_python_and_venv
+      name: Install python and create virtual environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3 python3-venv
+        python3 -m venv testing_venv
+        source testing_venv/bin/activate
+        python3 -m pip install --upgrade pip
+        echo PATH=$PATH >> $GITHUB_ENV
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: script
-          path: ./wazuh-install.sh
-          if-no-files-found: error
+    - name: Install Ansible
+      run: pip install ansible-core==2.16
+    
+    - &setup_aws_credentials
+      name: Set up AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+        aws-region: ${{ env.REGION }}
+    
+    - &checkout_wazuh_automation
+      name: Checkout wazuh/wazuh-automation repository
+      uses: actions/checkout@v4
+      with:
+        repository: wazuh/wazuh-automation
+        ref: ${{ env.AUTOMATION_REFERENCE }}
+        token: ${{ secrets.GH_CLONE_TOKEN }}
+        path: wazuh-automation
+    
+    - &install_and_set_allocator_requirements
+      name: Install and set allocator requirements
+      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
 
-  Test-offline-installation-debian:
+    - name: Allocate test instance and set SSH variables
+      id: allocator_instance
+      run: |
+        python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir $ALLOCATOR_PATH \
+          --track-output $ALLOCATOR_PATH/track-${{ matrix.system }}.yml --inventory-output $ALLOCATOR_PATH/inventory.yml --instance-name gha_${{ github.run_id }}_assistant_test \
+          --label-team devops --label-termination-date 1d --aws-account ${{ env.AWS_ACCOUNT }}
+
+        sed 's/: */=/g' $ALLOCATOR_PATH/inventory.yml > $ALLOCATOR_PATH/inventory_mod.yml
+        sed -i 's/-o StrictHostKeyChecking=no/\"-o StrictHostKeyChecking=no\"/g' $ALLOCATOR_PATH/inventory_mod.yml
+        source $ALLOCATOR_PATH/inventory_mod.yml
+
+        echo "[gha_instance]" > $ALLOCATOR_PATH/inventory-${{ matrix.system }}
+        echo "$ansible_host ansible_port=$ansible_port ansible_user=$ansible_user ansible_ssh_private_key_file=$ansible_ssh_private_key_file ansible_ssh_common_args='$ansible_ssh_common_args'" >> $ALLOCATOR_PATH/inventory-${{ matrix.system }}
+    
+    - name: Upload ansible inventory
+      uses: actions/upload-artifact@v4
+      with:
+        name: inventory-${{ matrix.system }}
+        path: $ALLOCATOR_PATH/inventory-${{ matrix.system }}
+        if-no-files-found: error
+
+    - name: Upload instance track
+      uses: actions/upload-artifact@v4
+      with:
+        name: track-${{ matrix.system }}
+        path: $ALLOCATOR_PATH/track-${{ matrix.system }}.yml
+        if-no-files-found: error
+
+  Test-offline-installation:
     runs-on: ubuntu-latest
-    needs: Build-wazuh-install-script
+    needs: Create-allocator-instances
+    strategy:
+      fail-fast: false
+      matrix:
+        system: ${{ github.event_name == 'pull_request' && fromJson('["Ubuntu_22", "CentOS_8"]') || fromJson(inputs.SYSTEMS) }}
+
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+    - name: Get system inventory
+      uses: actions/download-artifact@v4
+      with:
+        name: inventory-${{ matrix.system }}
+    
+    - *install_python_and_venv
+  
+    - name: Install Ansible
+      run: pip install ansible-core==2.16
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: script
+    - name: Execute provision playbook
+      run: |
+        INSTALL_DEPS=true
+        INSTALL_PYTHON=true
+        INSTALL_PIP_DEPS=true
 
-      - name: Move installation assistant script
-        run: cp $GITHUB_WORKSPACE/wazuh-install.sh $GITHUB_WORKSPACE/.github/actions/offline-installation/wazuh-install.sh
+        ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/provision.yml \
+        -i inventory-${{ matrix.system }} \
+        -l all \
+        -e "repository=$REPOSITORY_URL" \
+        -e "reference=$WAZUH_INSTALLATION_ASSISTANT_REFERENCE" \
+        -e "tmp_path=$TMP_PATH" \
+        -e "install_deps=$INSTALL_DEPS" \
+        -e "install_python=$INSTALL_PYTHON" \
+        -e "install_pip_deps=$INSTALL_PIP_DEPS" \
+        "$VERBOSITY"
 
-      - name: Run script
-        run: sudo bash $GITHUB_WORKSPACE/.github/actions/offline-installation/offline-installation.sh
-
-  Test-offline-installation-rpm:
+    - name: Execute offline installation playbook
+      run: |
+        ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook .github/workflows/ansible-playbooks/offline_installation.yml \
+        -i inventory-${{ matrix.system }} \
+        -l all \
+        -e "tmp_path=$TMP_PATH" \
+        -e "pkg_repository=$PKG_REPOSITORY" \
+        -e "wazuh_version=$WAZUH_VERSION" \
+        "$VERBOSITY"
+  
+  Release-instances:
     runs-on: ubuntu-latest
-    needs: Build-wazuh-install-script
+    needs: 
+      - Create-allocator-instances
+      - Test-offline-installation 
+    if: ${{ needs.Create-allocator-instances.result == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        system: ${{ github.event_name == 'pull_request' && fromJson('["Ubuntu_22", "CentOS_8"]') || fromJson(inputs.SYSTEMS) }}
+
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
+    - name: Get instance track
+      uses: actions/download-artifact@v4
+      with:
+        name: track-${{ matrix.system }}.yml
+    
+    - *install_python_and_venv
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: script
+    - *checkout_wazuh_automation
 
-      - name: Move installation assistant script
-        run: cp $GITHUB_WORKSPACE/wazuh-install.sh $GITHUB_WORKSPACE/.github/actions/offline-installation/wazuh-install.sh
+    - *install_and_set_allocator_requirements
 
-      - name: Launch docker and run script
-        run: sudo docker run -v $GITHUB_WORKSPACE/.github/actions/offline-installation/:/tests centos:centos7 bash /tests/offline-installation.sh
+    - name: Release test instance
+      run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output track-${{ matrix.system }}.yml --aws-profile ${{ env.AWS_ACCOUNT }}

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -46,7 +46,7 @@ on:
 
 env:
   WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.head_ref || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
-  AUTOMATION_REFERENCE: ${{ github.event_name == 'pull_request' && '4.10.2' || inputs.AUTOMATION_REFERENCE }}
+  AUTOMATION_REFERENCE: ${{ inputs.AUTOMATION_REFERENCE }}
   WAZUH_VERSION: "4.10"
   PKG_REPOSITORY: ${{ github.event_name == 'pull_request' && 'pre-release' || inputs.PKG_REPOSITORY }}
   #AWS_ACCOUNT: "wazuh-dev"

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -182,8 +182,7 @@ jobs:
 
     - name: Get instance-id and modify security group
       run: |
-        INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)
-        aws ec2 modify-instance-attribute --instance-id $INSTANCE_ID --groups sg-03c53339089a65829
+        aws ec2 modify-instance-attribute --instance-id $(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text) --groups sg-03c53339089a65829
 
     - name: Execute offline installation playbook
       run: |

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -135,12 +135,15 @@ jobs:
         role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
         aws-region: ${{ env.REGION }}
 
+    - name: Display Deployment Report
+      if: always()
+      run: echo ${{ env.AUTOMATION_REFERENCE }}
+
     - name: Checkout wazuh/wazuh-automation repository
       uses: actions/checkout@v4
       with:
         repository: wazuh/wazuh-automation
         ref: ${{ env.AUTOMATION_REFERENCE }}
-        token: ${{ secrets.GH_CLONE_TOKEN }}
         path: wazuh-automation
 
     - name: Install and set allocator requirements

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -182,7 +182,7 @@ jobs:
 
     - name: Get instance-id and modify security group
       run: |
-        echo "INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)"
+        INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)
         aws ec2 modify-instance-attribute --instance-id $INSTANCE_ID --groups sg-03c53339089a65829
 
     - name: Execute offline installation playbook

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -79,6 +79,14 @@ jobs:
       with:
         ref: ${{ env.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
 
+    - name: Checkout wazuh/wazuh-automation repository
+      uses: actions/checkout@v4
+      with:
+        repository: wazuh/wazuh-automation
+        ref: ${{ env.AUTOMATION_REFERENCE }}
+        token: ${{ secrets.GH_CLONE_TOKEN }}
+        path: wazuh-automation
+
     - name: Set COMPOSITE_NAME variable
       run: |
         case "${{ matrix.system }}" in
@@ -126,22 +134,14 @@ jobs:
         python3 -m pip install --upgrade pip
         echo PATH=$PATH >> $GITHUB_ENV
 
+    - name: Install and set allocator requirements
+      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
+
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v3
       with:
         role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
         aws-region: ${{ env.REGION }}
-
-    - name: Checkout wazuh/wazuh-automation repository
-      uses: actions/checkout@v4
-      with:
-        repository: wazuh/wazuh-automation
-        ref: ${{ env.AUTOMATION_REFERENCE }}
-        token: ${{ secrets.GH_CLONE_TOKEN }}
-        path: wazuh-automation
-
-    - name: Install and set allocator requirements
-      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
 
     - name: Allocate test instance and set SSH variables
       id: allocator_instance

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -180,13 +180,10 @@ jobs:
         -e "install_pip_deps=$INSTALL_PIP_DEPS" \
         "$VERBOSITY"
 
-    - name: Get instance-id
+    - name: Get instance-id and modify security group
       run: |
-        echo "INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)" >> $GITHUB_ENV
-
-    - name: Change security group
-      run: |
-        aws ec2 modify-instance-attribute --instance-id {{ env.INSTANCE_ID }} --groups sg-03c53339089a65829
+        echo "INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)"
+        aws ec2 modify-instance-attribute --instance-id $INSTANCE_ID --groups sg-03c53339089a65829
 
     - name: Execute offline installation playbook
       run: |

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -182,7 +182,8 @@ jobs:
 
     - name: Get instance-id
       run: |
-        echo "INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)" >> $GITHUB_ENV
+        INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)
+        echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
 
     - name: Change security group
       run: |

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -180,14 +180,14 @@ jobs:
         -e "install_pip_deps=$INSTALL_PIP_DEPS" \
         "$VERBOSITY"
 
-    #- name: Get instance-id
-    #  run: |
-    #    INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[0].Instances[0].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.#run_id }}_assistant_test" --output text)
-    #    echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
-#
-    #- name: Change security group
-    #  run: |
-    #    aws ec2 modify-instance-attribute --instance-id ${{ env.INSTANCE_ID }} --groups sg-03c53339089a65829
+    - name: Get instance-id
+      run: |
+        INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[0].Instances[0].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)
+        echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
+
+    - name: Change security group
+      run: |
+        aws ec2 modify-instance-attribute --instance-id ${{ env.INSTANCE_ID }} --groups sg-03c53339089a65829
 
     - name: Execute offline installation playbook
       run: |

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -180,14 +180,14 @@ jobs:
         -e "install_pip_deps=$INSTALL_PIP_DEPS" \
         "$VERBOSITY"
 
-    - name: Get instance-id
-      run: |
-        INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[0].Instances[0].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.run_id }}_assistant_test" --output text)
-        echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
-
-    - name: Change security group
-      run: |
-        aws ec2 modify-instance-attribute --instance-id ${{ env.INSTANCE_ID }} --groups sg-03c53339089a65829
+    #- name: Get instance-id
+    #  run: |
+    #    INSTANCE_ID=$(aws ec2 describe-instances --query 'Reservations[0].Instances[0].InstanceId' --filters "Name=tag:Name,Values=gha_${{ github.#run_id }}_assistant_test" --output text)
+    #    echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
+#
+    #- name: Change security group
+    #  run: |
+    #    aws ec2 modify-instance-attribute --instance-id ${{ env.INSTANCE_ID }} --groups sg-03c53339089a65829
 
     - name: Execute offline installation playbook
       run: |

--- a/builder.sh
+++ b/builder.sh
@@ -16,7 +16,7 @@ readonly resources_certs="${base_path_builder}/cert_tool"
 readonly resources_passwords="${base_path_builder}/passwords_tool"
 readonly resources_common="${base_path_builder}/common_functions"
 readonly resources_download="${base_path_builder}/downloader"
-source_branch="v4.11.0"
+source_branch="v4.10.0-rc2"
 
 function getHelp() {
 

--- a/install_functions/installVariables.sh
+++ b/install_functions/installVariables.sh
@@ -8,10 +8,10 @@
 
 ## Package vars
 readonly wazuh_major="4.11"
-readonly wazuh_version="4.11.0"
+readonly wazuh_version="4.10.0"
 readonly filebeat_version="7.10.2"
 readonly wazuh_install_vesion="0.1"
-source_branch="v${wazuh_version}"
+source_branch="v${wazuh_version}-rc2"
 
 repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"
 repobaseurl="https://packages.wazuh.com/4.x"

--- a/install_functions/wazuh-offline-download.sh
+++ b/install_functions/wazuh-offline-download.sh
@@ -7,7 +7,7 @@
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
-
+ 
 function offline_download() {
 
   common_logger "Starting Wazuh packages download."


### PR DESCRIPTION
# Description

The purpose of this PR is to add the `-d` option when generating packages in the Wazuh offline installation workflow. Also a new input has been added in the workflow_dispatch so that you can manually switch between staging or pre-release.

>[!WARNING]
> If enabled by a PR, it uses 'pre-release' by default.

