### PR TITLE
Changed runners in workflows to Ubuntu 22.04

### DIFF
--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -69,7 +69,7 @@ permissions:
 
 jobs:
   run-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false    # If a job fails, the rest of jobs will not be canceled
       matrix:

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -71,7 +71,7 @@ permissions:
 
 jobs:
   run-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false    # If a job fails, the rest of jobs will not be canceled
       matrix:

--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -53,7 +53,7 @@ permissions:
 
 jobs:
   Build_Installation_Assistant:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: View parameters

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   Build-wazuh-install-script:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master
@@ -36,7 +36,7 @@ jobs:
           if-no-files-found: error
 
   Test-offline-installation-debian:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: Build-wazuh-install-script
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
         run: sudo bash $GITHUB_WORKSPACE/.github/actions/offline-installation/offline-installation.sh
 
   Test-offline-installation-rpm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: Build-wazuh-install-script
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/password-tool.yml
+++ b/.github/workflows/password-tool.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Build password-tool and wazuh-install scripts
         run: |
           bash builder.sh -p
-          bash builder.sh -i -d staging
+          bash builder.sh -i
         shell: bash
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/password-tool.yml
+++ b/.github/workflows/password-tool.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Build password-tool and wazuh-install scripts
         run: |
           bash builder.sh -p
-          bash builder.sh -i
+          bash builder.sh -i -d staging
         shell: bash
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/password-tool.yml
+++ b/.github/workflows/password-tool.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   Build-password-tool-and-wazuh-install-scripts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Build password-tool and wazuh-install scripts
@@ -22,7 +22,7 @@ jobs:
           if-no-files-found: error
 
   test-password-tool-success:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: Build-password-tool-and-wazuh-install-scripts
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
         run: sudo bash .github/actions/passwords-tool/tests-stack-success.sh
 
   test-password-tool-failure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: Build-password-tool-and-wazuh-install-scripts
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Changed runners in workflows to ubuntu 22.04 ([#173](https://github.com/wazuh/wazuh-installation-assistant/pull/173))
+- None
 
 ### Fixed
 
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- None
+- Changed runners in workflows to Ubuntu 22.04 ([#185](https://github.com/wazuh/wazuh-installation-assistant/pull/185))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [4.10.3]
+
+### Added
+
+- None
+
+### Changed
+
+- Changed runners in workflows to ubuntu 22.04 ([#173](https://github.com/wazuh/wazuh-installation-assistant/pull/173))
+
+### Fixed
+
+- None
+
+### Deleted
+
+- None
+
 ## [4.10.2]
 
 ### Added

--- a/passwords_tool/passwordsFunctions.sh
+++ b/passwords_tool/passwordsFunctions.sh
@@ -5,6 +5,7 @@
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
+# Trigger
 
 function passwords_changePassword() {
 

--- a/passwords_tool/passwordsFunctions.sh
+++ b/passwords_tool/passwordsFunctions.sh
@@ -5,7 +5,6 @@
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
-# Trigger
 
 function passwords_changePassword() {
 


### PR DESCRIPTION
## Related

- https://github.com/wazuh/wazuh-installation-assistant/issues/165

# Description

The aim of this PR is to change the Linux image used in the Github Actions runners that we use from `ubuntu-latest` to `ubuntu-22.04`.

## Tests

- :white_check_mark: Test Installation Assistant [here](https://github.com/wazuh/wazuh-installation-assistant/actions/runs/12412379480).
- :white_check_mark: Test Installation Assistant distributed [here](https://github.com/wazuh/wazuh-installation-assistant/actions/runs/12413063840).
- :white_check_mark: Installation Assistant build [here](https://github.com/wazuh/wazuh-installation-assistant/actions/runs/12396614774).
- :x: Offline Installation (this workflow is broken right now and we are working in the fix in [this issue](https://github.com/wazuh/wazuh-installation-assistant/issues/161). This change is preventive as the `ubuntu-latest` image is using the `ubuntu-22.04` image so it should work).
- :warning: Passwords tool (this workflow only runs when changing files in the passwords-tool directory and cant be run pointing  to this branch because  it look for packages of 4.10.3 that we do not have. Another sucessfully run can be seen [here](https://github.com/wazuh/wazuh-installation-assistant/actions/runs/12396215542?pr=170). This workflow run uses `ubuntu-latest` but when it was ran `ubuntu-latest` image corresponded to `ubuntu-22.04` Also, this workflow suffered a fix tracked in [this issue](https://github.com/wazuh/wazuh-installation-assistant/issues/162)).

