### PR TITLE
Add function to change the source_branch with the current stage with --develoment flag activated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Add function to change the source_branch with the current stage with --develoment flag activated ([#211](https://github.com/wazuh/wazuh-installation-assistant/pull/211))
 - Update upload and download artifact actions to v4 ([#198](https://github.com/wazuh/wazuh-installation-assistant/pull/198))
 - Add venv to installation assistant workflows ([#134](https://github.com/wazuh/wazuh-installation-assistant/pull/134))
 

--- a/install_functions/checks.sh
+++ b/install_functions/checks.sh
@@ -478,7 +478,7 @@ function checks_filebeatURL() {
 }
 
 function checks_development_source_tag() {
-    actual_stage=""
+    last_stage=""
     source_branch="${source_branch}-${actual_stage}"
 
     # Check if the statge tag exists

--- a/install_functions/checks.sh
+++ b/install_functions/checks.sh
@@ -486,7 +486,7 @@ function checks_development_source_tag() {
         "https://api.github.com/repos/wazuh/wazuh-installation-assistant/git/refs/tags/$source_branch")
 
     if [ "$status_code" -ne 200 ]; then
-        common_logger -e "Tag '$source_branch' does not exist. Using the source branch related to the Wazuh version ($wazuh_version)."
+        common_logger -e "Tag '$source_branch' does not exist. Using the source branch related to the Wazuh version (${source_branch#v})."
         source_branch="${wazuh_version}"
 
         # Check if the source branch exists

--- a/install_functions/checks.sh
+++ b/install_functions/checks.sh
@@ -477,6 +477,34 @@ function checks_filebeatURL() {
     fi
 }
 
+function checks_development_source_tag() {
+    actual_stage=""
+    source_branch="${source_branch}-${actual_stage}"
+
+    # Check if the statge tag exists
+    status_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        "https://api.github.com/repos/wazuh/wazuh-installation-assistant/git/refs/tags/$source_branch")
+
+    if [ "$status_code" -ne 200 ]; then
+        common_logger -e "Tag '$source_branch' does not exist. Using the source branch related to the Wazuh version."
+        source_branch="${wazuh_version}"
+
+        # Check if the source branch exists
+        checks_source_branch  
+    fi
+}
+
+function checks_source_branch() {
+    # Check if the source branch exists
+    status_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        "https://api.github.com/repos/wazuh/wazuh-installation-assistant/branches/$source_branch")
+
+    if [ "$status_code" -ne 200 ]; then
+        common_logger -e "Branch '$source_branch' does not exist. Using the main branch."
+        source_branch="main"
+    fi
+}
+
 function checks_firewall(){
     ports_list=("$@")
     f_ports=""

--- a/install_functions/checks.sh
+++ b/install_functions/checks.sh
@@ -481,7 +481,7 @@ function checks_development_source_tag() {
     last_stage=""
     source_branch="${source_branch}-${last_stage}"
 
-    # Check if the statge tag exists
+    # Check if the stage tag exists
     status_code=$(curl -s -o /dev/null -w "%{http_code}" \
         "https://api.github.com/repos/wazuh/wazuh-installation-assistant/git/refs/tags/$source_branch")
 

--- a/install_functions/checks.sh
+++ b/install_functions/checks.sh
@@ -462,7 +462,7 @@ function checks_filebeatURL() {
 
     # URL using master branch
     new_filebeat_url="${filebeat_wazuh_template/${source_branch}/master}"
-    
+
     response=$(curl -I --write-out '%{http_code}' --silent --output /dev/null $filebeat_wazuh_template)
     if [ "${response}" != "200" ]; then
         response=$(curl -I --write-out '%{http_code}' --silent --output /dev/null $new_filebeat_url)
@@ -478,7 +478,6 @@ function checks_filebeatURL() {
 }
 
 function checks_development_source_tag() {
-    last_stage=""
     source_branch="${source_branch}-${last_stage}"
 
     # Check if the stage tag exists
@@ -486,11 +485,11 @@ function checks_development_source_tag() {
         "https://api.github.com/repos/wazuh/wazuh-installation-assistant/git/refs/tags/$source_branch")
 
     if [ "$status_code" -ne 200 ]; then
-        common_logger -e "Tag '$source_branch' does not exist. Using the source branch related to the Wazuh version ($wazuh_version)."
+        common_logger -w "Tag '$source_branch' does not exist. Using the source branch related to the Wazuh version ($wazuh_version)."
         source_branch="${wazuh_version}"
 
         # Check if the source branch exists
-        checks_source_branch  
+        checks_source_branch
     fi
 }
 
@@ -500,7 +499,7 @@ function checks_source_branch() {
         "https://api.github.com/repos/wazuh/wazuh-installation-assistant/branches/$source_branch")
 
     if [ "$status_code" -ne 200 ]; then
-        common_logger -e "Branch '$source_branch' does not exist. Using the main branch."
+        common_logger -w "Branch '$source_branch' does not exist. Using the main branch."
         source_branch="main"
     fi
 }

--- a/install_functions/checks.sh
+++ b/install_functions/checks.sh
@@ -479,7 +479,7 @@ function checks_filebeatURL() {
 
 function checks_development_source_tag() {
     last_stage=""
-    source_branch="${source_branch}-${actual_stage}"
+    source_branch="${source_branch}-${last_stage}"
 
     # Check if the statge tag exists
     status_code=$(curl -s -o /dev/null -w "%{http_code}" \

--- a/install_functions/checks.sh
+++ b/install_functions/checks.sh
@@ -486,7 +486,7 @@ function checks_development_source_tag() {
         "https://api.github.com/repos/wazuh/wazuh-installation-assistant/git/refs/tags/$source_branch")
 
     if [ "$status_code" -ne 200 ]; then
-        common_logger -e "Tag '$source_branch' does not exist. Using the source branch related to the Wazuh version (${source_branch#v})."
+        common_logger -e "Tag '$source_branch' does not exist. Using the source branch related to the Wazuh version ($wazuh_version)."
         source_branch="${wazuh_version}"
 
         # Check if the source branch exists

--- a/install_functions/checks.sh
+++ b/install_functions/checks.sh
@@ -486,7 +486,7 @@ function checks_development_source_tag() {
         "https://api.github.com/repos/wazuh/wazuh-installation-assistant/git/refs/tags/$source_branch")
 
     if [ "$status_code" -ne 200 ]; then
-        common_logger -e "Tag '$source_branch' does not exist. Using the source branch related to the Wazuh version."
+        common_logger -e "Tag '$source_branch' does not exist. Using the source branch related to the Wazuh version ($wazuh_version)."
         source_branch="${wazuh_version}"
 
         # Check if the source branch exists

--- a/install_functions/installMain.sh
+++ b/install_functions/installMain.sh
@@ -116,6 +116,7 @@ function main() {
                     devrepo="pre-release"
                     shift 1
                 fi
+                checks_development_source_tag
                 repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"
                 repobaseurl="https://packages-dev.wazuh.com/${devrepo}"
                 reporelease="unstable"

--- a/install_functions/installVariables.sh
+++ b/install_functions/installVariables.sh
@@ -12,6 +12,7 @@ readonly wazuh_version="4.11.0"
 readonly filebeat_version="7.10.2"
 readonly wazuh_install_vesion="0.1"
 source_branch="v${wazuh_version}"
+last_stage=""
 
 repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"
 repobaseurl="https://packages.wazuh.com/4.x"


### PR DESCRIPTION
# Description

Two functions have been created for validation of both the tag and the branch:

- **`checks_development_source_tag()`**: Validates that the current tag is correct by checking if it exists in the repository. If not, it uses the branch of the version being deployed for Wazuh.
- **`checks_source_branch()`**: Validates that the branch is correct by checking if it exists in the repository. If not, it uses `main`.

The `checks_development_source_tag()` function will modify the name of `source_branch` by appending the current stage. It is called when the `--development` flag is activated.

### Tests

- The related tests can be found here: https://github.com/wazuh/wazuh-installation-assistant/issues/203#issuecomment-2598665310



### New test

- Correct branch 4.11.0 and incorrect stage
``` console
[root@xx-xx-xx-xx vagrant]# bash wazuh-install.sh -a -d
      20/01/2025 19:12:58 WARNING: Tag 'v4.11.0-rc1' does not exist. Using the source branch related to the Wazuh version (4.11.0).

```

- No stage

``` console
[root@xx-xx-xx-xx vagrant]# bash wazuh-install.sh -a -d
      20/01/2025 19:12:27 WARNING: Tag 'v4.11.0-' does not exist. Using the source branch related to the Wazuh version (4.11.0).

```

- Incorrect version
```console
[root@xx-xx-xx-xx vagrant]# bash wazuh-install.sh -a -d
20/01/2025 19:14:34 WARNING: Tag 'v4.11.o-rc1' does not exist. Using the source branch related to the Wazuh version (4.11.o).
20/01/2025 19:14:34 WARNING: Branch '4.11.o' does not exist. Using the main branch.

```

- Without development mode and stage in 4.10.1-rc1 (install from v4.10.1)

	<details>
	<summary>4.10.1 installation</summary>
	
	```console
	


        [root@xx-xx-xx-xx vagrant]# bash wazuh-install.sh -a
        20/01/2025 19:16:34 INFO: Starting Wazuh installation assistant. Wazuh version: 4.10.0 (x86_64/AMD64)
        20/01/2025 19:16:34 INFO: Verbose logging redirected to /var/log/wazuh-install.log
        20/01/2025 19:16:35 INFO: Verifying that your system meets the recommended minimum hardware requirements.
        20/01/2025 19:16:35 INFO: Wazuh web interface port will be 443.
        20/01/2025 19:16:35 WARNING: The system has Firewalld enabled. Please ensure that traffic is allowed on these ports: 1515, 1514, 443.
        20/01/2025 19:16:35 INFO: Wazuh repository added.
        20/01/2025 19:16:35 INFO: --- Configuration files ---
        20/01/2025 19:16:35 INFO: Generating configuration files.
        20/01/2025 19:16:35 INFO: Generating the root certificate.
        20/01/2025 19:16:35 INFO: Generating Admin certificates.
        20/01/2025 19:16:35 INFO: Generating Wazuh indexer certificates.
        20/01/2025 19:16:35 INFO: Generating Filebeat certificates.
        20/01/2025 19:16:36 INFO: Generating Wazuh dashboard certificates.
        20/01/2025 19:16:36 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
        20/01/2025 19:16:36 INFO: --- Wazuh indexer ---
        20/01/2025 19:16:36 INFO: Starting Wazuh indexer installation.
        20/01/2025 19:18:01 INFO: Wazuh indexer installation finished.
        20/01/2025 19:18:01 INFO: Wazuh indexer post-install configuration finished.
        20/01/2025 19:18:01 INFO: Starting service wazuh-indexer.
        20/01/2025 19:18:16 INFO: wazuh-indexer service started.
        20/01/2025 19:18:16 INFO: Initializing Wazuh indexer cluster security settings.
        20/01/2025 19:18:20 INFO: Wazuh indexer cluster security configuration initialized.
        20/01/2025 19:18:20 INFO: Wazuh indexer cluster initialized.
        20/01/2025 19:18:20 INFO: --- Wazuh server ---
        20/01/2025 19:18:20 INFO: Starting the Wazuh manager installation.
        20/01/2025 19:20:00 INFO: Wazuh manager installation finished.
        20/01/2025 19:20:00 INFO: Wazuh manager vulnerability detection configuration finished.
        20/01/2025 19:20:00 INFO: Starting service wazuh-manager.
        20/01/2025 19:20:13 INFO: wazuh-manager service started.
        20/01/2025 19:20:13 INFO: Starting Filebeat installation.
        20/01/2025 19:20:16 INFO: Filebeat installation finished.
        20/01/2025 19:20:17 INFO: Filebeat post-install configuration finished.
        20/01/2025 19:20:17 INFO: Starting service filebeat.
        20/01/2025 19:20:18 INFO: filebeat service started.
        20/01/2025 19:20:18 INFO: --- Wazuh dashboard ---
        20/01/2025 19:20:18 INFO: Starting Wazuh dashboard installation.
        20/01/2025 19:21:48 INFO: Wazuh dashboard installation finished.
        20/01/2025 19:21:48 INFO: Wazuh dashboard post-install configuration finished.
        20/01/2025 19:21:48 INFO: Starting service wazuh-dashboard.
        20/01/2025 19:21:48 INFO: wazuh-dashboard service started.
        20/01/2025 19:21:49 INFO: Updating the internal users.
        20/01/2025 19:21:52 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
        20/01/2025 19:22:04 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
        20/01/2025 19:22:37 INFO: Initializing Wazuh dashboard web application.
        20/01/2025 19:22:37 INFO: Wazuh dashboard web application not yet initialized. Waiting...
        20/01/2025 19:22:53 INFO: Wazuh dashboard web application not yet initialized. Waiting...
        20/01/2025 19:23:08 INFO: Wazuh dashboard web application initialized.
        20/01/2025 19:23:08 INFO: --- Summary ---
        20/01/2025 19:23:08 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
            User: admin
            Password: xxxxxxxxxxxxx
        20/01/2025 19:23:08 INFO: Installation finished.
        [root@xx-xx-xx-xx vagrant]# 

	```
	
	![Image](https://github.com/user-attachments/assets/8ae6afd6-9459-4e4e-b9bc-352c68bb7709)
	
	</details>
