### PR TITLE
Fix error related with Filebeat template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix error related with Filebeat template ([#222](https://github.com/wazuh/wazuh-installation-assistant/pull/222))
 - Update `-d` option in the password tool workflow and fix test scripts ([#170](https://github.com/wazuh/wazuh-installation-assistant/pull/170))
 - Added architecture information to assistant. ([#92](https://github.com/wazuh/wazuh-installation-assistant/pull/92))
 

--- a/install_functions/checks.sh
+++ b/install_functions/checks.sh
@@ -455,13 +455,13 @@ function checks_available_port() {
 
 function checks_filebeatURL() {
     # URL uses branch when the source_branch is not a stage branch
-    if [[ ! "${source_branch}" =~ "-" ]]; then
+    if [[ ! $last_stage ]]; then
         source_branch="${source_branch#v}"
         filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
     fi
 
     # URL using master branch
-    new_filebeat_url="${filebeat_wazuh_template/${source_branch}/master}"
+    new_filebeat_url="${filebeat_wazuh_template/${source_branch}/main}"
 
     response=$(curl -I --write-out '%{http_code}' --silent --output /dev/null $filebeat_wazuh_template)
     if [ "${response}" != "200" ]; then
@@ -469,7 +469,7 @@ function checks_filebeatURL() {
 
         # Display error if both URLs do not get the resource
         if [ "${response}" != "200" ]; then
-            common_logger -e "Error: Could not get the Filebeat Wazuh template."
+            common_logger -e "Could not get the Filebeat Wazuh template."
         else
             common_logger "Using Filebeat template from master branch."
             filebeat_wazuh_template="${new_filebeat_url}"

--- a/install_functions/installMain.sh
+++ b/install_functions/installMain.sh
@@ -120,6 +120,7 @@ function main() {
                 repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"
                 repobaseurl="https://packages-dev.wazuh.com/${devrepo}"
                 reporelease="unstable"
+                filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
                 filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.4.tar.gz"
                 bucket="packages-dev.wazuh.com"
                 repository="${devrepo}"


### PR DESCRIPTION
# Description

When trying to install Wazuh using the installation assistant, the following error is displayed:
```console
24/01/2025 21:17:38 ERROR: Error downloading wazuh-template.json file."
```

This error occurs because the template cannot be retrieved correctly, meaning the URL is incorrect. If we debug the code and print the URL it is trying to access (aiming to retrieve the URL for `v4.11.0-alpha1`), we get the following:
```console
Filebeat Wazuh template is: https://raw.githubusercontent.com/wazuh/wazuh/v4.11.0/extensions/elasticsearch/7.x/wazuh-template.json
```
The issue arises because `source_branch` is not being updated properly in the `filebeat_wazuh_template` variable.


Additionally, when trying to check the Filebeat URL in the `check_FilebeatURL()`  function, if the branch does not exist, it will attempt to retrieve the URL from `master`, causing an error since the repository's default branch is `main`.

The purpose of this PR is to update the Filebeat template with the correct value of  `source_branch` and fix the issue in `check_FilebeatURL()` by changing the default branch from `master` to `main`.

## Tests

- Installing Wazuh v4.11.0-alpha1.

	<details><summary>Installation logs</summary>
	
	```console
	vagrant@ubuntu22-aio-components-8909:~$ sudo bash wazuh-install.sh -a -v -o -d
	wazuh-install.sh: line 1: W#!/bin/bash: No such file or directory
	27/01/2025 09:47:59 DEBUG: Checking root permissions.
	27/01/2025 09:47:59 DEBUG: Checking sudo package.
	27/01/2025 09:47:59 INFO: Starting Wazuh installation assistant. Wazuh version: 4.11.0 (x86_64/AMD64)
	27/01/2025 09:47:59 INFO: Verbose logging redirected to /var/log/wazuh-install.log
	27/01/2025 09:47:59 DEBUG: APT package manager will be used.
	27/01/2025 09:47:59 DEBUG: Checking system distribution.
	27/01/2025 09:47:59 DEBUG: Detected distribution name: ubuntu
	27/01/2025 09:47:59 DEBUG: Detected distribution version: 22
	27/01/2025 09:47:59 DEBUG: Installing check dependencies.
	Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
	Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
	Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
	Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
	Reading package lists...
	27/01/2025 09:48:02 DEBUG: Checking Wazuh installation.
	27/01/2025 09:48:03 INFO: --- Removing existing Wazuh installation ---
	27/01/2025 09:48:03 DEBUG: Removing GPG key from system.
	27/01/2025 09:48:03 INFO: Wazuh GPG key not found in the system
	27/01/2025 09:48:03 INFO: Installation cleaned.
	27/01/2025 09:48:04 DEBUG: Checking system architecture.
	27/01/2025 09:48:04 INFO: Verifying that your system meets the recommended minimum hardware requirements.
	27/01/2025 09:48:04 DEBUG: CPU cores detected: 4
	27/01/2025 09:48:04 DEBUG: Free RAM memory detected: 7937
	27/01/2025 09:48:04 INFO: Wazuh web interface port will be 443.
	27/01/2025 09:48:04 DEBUG: Checking ports availability.
	Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
	Hit:2 http://security.ubuntu.com/ubuntu jammy-security InRelease
	Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
	Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
	Reading package lists...
	27/01/2025 09:48:05 DEBUG: Installing prerequisites dependencies.
	27/01/2025 09:48:07 DEBUG: Checking curl tool version.
	27/01/2025 09:48:07 DEBUG: Adding the Wazuh repository.
	gpg: keyring '/usr/share/keyrings/wazuh.gpg' created
	gpg: key 96B3EE5F29111145: public key "Wazuh.com (Wazuh Signing Key) <support@wazuh.com>" imported
	gpg: Total number processed: 1
	gpg:               imported: 1
	deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main
	Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
	Hit:2 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
	Hit:3 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
	Hit:4 http://security.ubuntu.com/ubuntu jammy-security InRelease
	Get:5 https://packages-dev.wazuh.com/pre-release/apt unstable InRelease [17.3 kB]
	Get:6 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 Packages [43.8 kB]
	Fetched 61.0 kB in 1s (46.7 kB/s)
	Reading package lists...
	27/01/2025 09:48:10 INFO: Wazuh development repository added.
	27/01/2025 09:48:10 INFO: --- Configuration files ---
	27/01/2025 09:48:10 INFO: Generating configuration files.
	27/01/2025 09:48:10 DEBUG: Creating Wazuh certificates.
	27/01/2025 09:48:10 DEBUG: Reading configuration file.
	27/01/2025 09:48:10 DEBUG: Checking if 127.0.0.1 is private.
	27/01/2025 09:48:10 DEBUG: Checking if 127.0.0.1 is private.
	27/01/2025 09:48:10 DEBUG: Checking if 127.0.0.1 is private.
	27/01/2025 09:48:10 INFO: Generating the root certificate.
	27/01/2025 09:48:11 INFO: Generating Admin certificates.
	27/01/2025 09:48:11 DEBUG: Generating Admin private key.
	27/01/2025 09:48:11 DEBUG: Converting Admin private key to PKCS8 format.
	27/01/2025 09:48:11 DEBUG: Generating Admin CSR.
	27/01/2025 09:48:11 DEBUG: Creating Admin certificate.
	27/01/2025 09:48:11 INFO: Generating Wazuh indexer certificates.
	27/01/2025 09:48:11 DEBUG: Creating the certificates for wazuh-indexer indexer node.
	27/01/2025 09:48:11 DEBUG: Generating certificate configuration.
	27/01/2025 09:48:11 DEBUG: Creating the Wazuh indexer tmp key pair.
	27/01/2025 09:48:11 DEBUG: Creating the Wazuh indexer certificates.
	27/01/2025 09:48:11 INFO: Generating Filebeat certificates.
	27/01/2025 09:48:11 DEBUG: Generating the certificates for wazuh-server server node.
	27/01/2025 09:48:11 DEBUG: Generating certificate configuration.
	27/01/2025 09:48:11 DEBUG: Creating the Wazuh server tmp key pair.
	27/01/2025 09:48:11 DEBUG: Creating the Wazuh server certificates.
	27/01/2025 09:48:11 INFO: Generating Wazuh dashboard certificates.
	27/01/2025 09:48:11 DEBUG: Generating certificate configuration.
	27/01/2025 09:48:11 DEBUG: Creating the Wazuh dashboard tmp key pair.
	27/01/2025 09:48:12 DEBUG: Creating the Wazuh dashboard certificates.
	27/01/2025 09:48:12 DEBUG: Cleaning certificate files.
	27/01/2025 09:48:12 DEBUG: Generating password file.
	27/01/2025 09:48:12 DEBUG: Generating random passwords.
	27/01/2025 09:48:12 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
	27/01/2025 09:48:12 DEBUG: Extracting Wazuh configuration.
	27/01/2025 09:48:12 DEBUG: Reading configuration file.
	27/01/2025 09:48:12 DEBUG: Checking if 127.0.0.1 is private.
	27/01/2025 09:48:12 DEBUG: Checking if 127.0.0.1 is private.
	27/01/2025 09:48:12 DEBUG: Checking if 127.0.0.1 is private.
	27/01/2025 09:48:12 INFO: --- Wazuh indexer ---
	27/01/2025 09:48:12 INFO: Starting Wazuh indexer installation.
	27/01/2025 09:48:12 INFO: Another process is using APT. Waiting for it to release the lock. Next retry in 30 seconds (1/10)
	Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-indexer 0 upgraded, 1 newly installed, 0 to remove and 50 not upgraded. Need to get 0 B/870 MB of archives. After this operation, 1097 MB of additional disk space will be used. Selecting pre NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-122-generic NEEDRESTART-KEXP: 5.15.0-122-generic NEEDRESTART-KSTA: 1art automatically using systemd
	27/01/2025 09:48:49 DEBUG: Checking Wazuh installation.
	27/01/2025 09:48:50 DEBUG: There are Wazuh indexer remaining files.
	27/01/2025 09:48:50 INFO: Wazuh indexer installation finished.
	27/01/2025 09:48:50 DEBUG: Configuring Wazuh indexer.
	27/01/2025 09:48:50 DEBUG: Copying Wazuh indexer certificates.
	27/01/2025 09:48:50 INFO: Wazuh indexer post-install configuration finished.
	27/01/2025 09:48:50 INFO: Starting service wazuh-indexer.
	Synchronizing state of wazuh-indexer.service with SysV service script with /lib/systemd/systemd-sysv-install.
	Executing: /lib/systemd/systemd-sysv-install enable wazuh-indexer
	27/01/2025 09:48:58 INFO: wazuh-indexer service started.
	27/01/2025 09:48:58 INFO: Initializing Wazuh indexer cluster security settings.
	**************************************************************************
	** This tool will be deprecated in the next major release of OpenSearch **
	** https://github.com/opensearch-project/security/issues/1755           **
	**************************************************************************
	Security Admin v7
	Will connect to 127.0.0.1:9200 ... done
	Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
	OpenSearch Version: 2.16.0
	Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
	Clustername: wazuh-cluster
	Clusterstate: GREEN
	Number of nodes: 1
	Number of data nodes: 1
	.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
	Populate config from /etc/wazuh-indexer/opensearch-security/
	Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
	   SUCC: Configuration for 'config' created or updated
	Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
	   SUCC: Configuration for 'roles' created or updated
	Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
	   SUCC: Configuration for 'rolesmapping' created or updated
	Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
	   SUCC: Configuration for 'internalusers' created or updated
	Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
	   SUCC: Configuration for 'actiongroups' created or updated
	Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
	   SUCC: Configuration for 'tenants' created or updated
	Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
	   SUCC: Configuration for 'nodesdn' created or updated
	Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
	   SUCC: Configuration for 'whitelist' created or updated
	Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
	   SUCC: Configuration for 'audit' created or updated
	Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
	   SUCC: Configuration for 'allowlist' created or updated
	SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","actiongroups","config","internalusers"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","actiongroups","config","internalusers"]) due to: null
	Done with success
	27/01/2025 09:49:00 INFO: Wazuh indexer cluster security configuration initialized.
	27/01/2025 09:49:00 INFO: Wazuh indexer cluster initialized.
	27/01/2025 09:49:00 INFO: --- Wazuh server ---
	27/01/2025 09:49:00 INFO: Starting the Wazuh manager installation.
	Reading package lists... Building dependency tree... Reading state information... Suggested packages: expect The following NEW packages will be installed: wazuh-manager 0 upgraded, 1 newly installed, 0 to remove and 50 not upgraded. Need to get 0 B/369 MB of archives. After this operation, 929 MB of additional disk space w NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-122-generic NEEDRESTART-KEXP: 5.15.0-122-generic NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: wazuh-indexer.service
	27/01/2025 09:49:42 DEBUG: Checking Wazuh installation.
	27/01/2025 09:49:42 DEBUG: There are Wazuh remaining files.
	27/01/2025 09:49:42 DEBUG: There are Wazuh indexer remaining files.
	27/01/2025 09:49:42 INFO: Wazuh manager installation finished.
	27/01/2025 09:49:42 DEBUG: Configuring Wazuh manager.
	27/01/2025 09:49:42 DEBUG: Setting provisional Wazuh indexer password.
	27/01/2025 09:49:42 INFO: Wazuh manager vulnerability detection configuration finished.
	27/01/2025 09:49:42 INFO: Starting service wazuh-manager.
	Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.
	27/01/2025 09:49:58 INFO: wazuh-manager service started.
	27/01/2025 09:49:58 INFO: Starting Filebeat installation.
	Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: filebeat 0 upgraded, 1 newly installed, 0 to remove and 50 not upgraded. Need to get 0 B/22.1 MB of archives. After this operation, 73.6 MB of additional disk space will be used. Selecting previou NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-122-generic NEEDRESTART-KEXP: 5.15.0-122-generic NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: wazuh-indexer.service
	27/01/2025 09:50:00 DEBUG: Checking Wazuh installation.
	27/01/2025 09:50:00 DEBUG: There are Wazuh remaining files.
	27/01/2025 09:50:01 DEBUG: There are Wazuh indexer remaining files.
	27/01/2025 09:50:01 DEBUG: There are Filebeat remaining files.
	27/01/2025 09:50:01 INFO: Filebeat installation finished.
	27/01/2025 09:50:01 DEBUG: Configuring Filebeat.
	
	
	Filebeat Wazuh template is: https://raw.githubusercontent.com/wazuh/wazuh/v4.11.0-alpha1/extensions/elasticsearch/7.x/wazuh-template.json
	
	
	27/01/2025 09:50:01 DEBUG: Filebeat template was download successfully.
	wazuh/
	wazuh/_meta/
	wazuh/_meta/config.yml
	wazuh/_meta/docs.asciidoc
	wazuh/_meta/fields.yml
	wazuh/archives/
	wazuh/archives/ingest/
	wazuh/archives/ingest/pipeline.json
	wazuh/archives/config/
	wazuh/archives/config/archives.yml
	wazuh/archives/manifest.yml
	wazuh/module.yml
	wazuh/alerts/
	wazuh/alerts/ingest/
	wazuh/alerts/ingest/pipeline.json
	wazuh/alerts/config/
	wazuh/alerts/config/alerts.yml
	wazuh/alerts/manifest.yml
	27/01/2025 09:50:02 DEBUG: Filebeat module was downloaded successfully.
	27/01/2025 09:50:02 DEBUG: Copying Filebeat certificates.
	Created filebeat keystore
	Successfully updated the keystore
	Successfully updated the keystore
	27/01/2025 09:50:02 INFO: Filebeat post-install configuration finished.
	27/01/2025 09:50:02 INFO: Starting service filebeat.
	Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
	Executing: /lib/systemd/systemd-sysv-install enable filebeat
	Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.
	27/01/2025 09:50:03 INFO: filebeat service started.
	27/01/2025 09:50:03 INFO: --- Wazuh dashboard ---
	27/01/2025 09:50:03 INFO: Starting Wazuh dashboard installation.
	Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-dashboard 0 upgraded, 1 newly installed, 0 to remove and 50 not upgraded. Need to get 174 MB of archives. After this operation, 957 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-dashboard amd64 4.11.0-1 [174 MB] Fetched 174 MB in 9s (19.1 MB/s) Selecting previously unselected  NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-122-generic NEEDRESTART-KEXP: 5.15.0-122-generic NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: wazuh-indexer.service
	27/01/2025 09:50:34 DEBUG: Checking Wazuh installation.
	27/01/2025 09:50:35 DEBUG: There are Wazuh remaining files.
	27/01/2025 09:50:35 DEBUG: There are Wazuh indexer remaining files.
	27/01/2025 09:50:35 DEBUG: There are Filebeat remaining files.
	27/01/2025 09:50:35 DEBUG: There are Wazuh dashboard remaining files.
	27/01/2025 09:50:35 INFO: Wazuh dashboard installation finished.
	27/01/2025 09:50:35 DEBUG: Configuring Wazuh dashboard.
	27/01/2025 09:50:35 DEBUG: Copying Wazuh dashboard certificates.
	27/01/2025 09:50:35 DEBUG: Wazuh dashboard certificate setup finished.
	27/01/2025 09:50:35 INFO: Wazuh dashboard post-install configuration finished.
	27/01/2025 09:50:35 INFO: Starting service wazuh-dashboard.
	Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
	27/01/2025 09:50:35 INFO: wazuh-dashboard service started.
	27/01/2025 09:50:35 DEBUG: Setting Wazuh indexer cluster passwords.
	27/01/2025 09:50:35 DEBUG: Checking Wazuh installation.
	27/01/2025 09:50:36 DEBUG: There are Wazuh remaining files.
	27/01/2025 09:50:36 DEBUG: There are Wazuh indexer remaining files.
	27/01/2025 09:50:36 DEBUG: There are Filebeat remaining files.
	27/01/2025 09:50:36 DEBUG: There are Wazuh dashboard remaining files.
	27/01/2025 09:50:36 INFO: Updating the internal users.
	27/01/2025 09:50:36 DEBUG: Creating password backup.
	**************************************************************************
	** This tool will be deprecated in the next major release of OpenSearch **
	** https://github.com/opensearch-project/security/issues/1755           **
	**************************************************************************
	Security Admin v7
	Will connect to 127.0.0.1:9200 ... done
	Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
	OpenSearch Version: 2.16.0
	Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
	Clustername: wazuh-cluster
	Clusterstate: GREEN
	Number of nodes: 1
	Number of data nodes: 1
	.opendistro_security index already exists, so we do not need to create one.
	Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
	   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
	Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
	   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
	Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
	   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
	Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
	   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
	Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
	   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
	Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
	   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
	Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
	   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
	Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
	   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
	Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
	   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
	Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
	   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
	27/01/2025 09:50:38 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
	27/01/2025 09:50:38 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
	27/01/2025 09:50:38 DEBUG: The internal users have been updated before changing the passwords.
	27/01/2025 09:50:38 DEBUG: Generating password hashes.
	27/01/2025 09:50:43 DEBUG: Password hashes generated.
	27/01/2025 09:50:43 DEBUG: Creating password backup.
	**************************************************************************
	** This tool will be deprecated in the next major release of OpenSearch **
	** https://github.com/opensearch-project/security/issues/1755           **
	**************************************************************************
	Security Admin v7
	Will connect to 127.0.0.1:9200 ... done
	Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
	OpenSearch Version: 2.16.0
	Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
	Clustername: wazuh-cluster
	Clusterstate: GREEN
	Number of nodes: 1
	Number of data nodes: 1
	.opendistro_security index already exists, so we do not need to create one.
	Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
	   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
	Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
	   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
	Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
	   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
	Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
	   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
	Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
	   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
	Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
	   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
	Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
	   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
	Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
	   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
	Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
	   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
	Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
	   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
	27/01/2025 09:50:45 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
	Successfully updated the keystore
	Successfully updated the keystore
	27/01/2025 09:50:45 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
	27/01/2025 09:50:45 DEBUG: Restarting filebeat service...
	27/01/2025 09:50:46 DEBUG: filebeat started.
	27/01/2025 09:50:46 DEBUG: Restarting wazuh-manager service...
	27/01/2025 09:51:04 DEBUG: wazuh-manager started.
	27/01/2025 09:51:05 DEBUG: Restarting wazuh-dashboard service...
	27/01/2025 09:51:05 DEBUG: wazuh-dashboard started.
	27/01/2025 09:51:05 DEBUG: Running security admin tool.
	27/01/2025 09:51:05 DEBUG: Loading new passwords changes.
	**************************************************************************
	** This tool will be deprecated in the next major release of OpenSearch **
	** https://github.com/opensearch-project/security/issues/1755           **
	**************************************************************************
	Security Admin v7
	Will connect to 127.0.0.1:9200 ... done
	Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
	OpenSearch Version: 2.16.0
	Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
	Clustername: wazuh-cluster
	Clusterstate: GREEN
	Number of nodes: 1
	Number of data nodes: 1
	.opendistro_security index already exists, so we do not need to create one.
	Populate config from /home/vagrant
	Force type: internalusers
	Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
	   SUCC: Configuration for 'internalusers' created or updated
	SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
	Done with success
	27/01/2025 09:51:07 DEBUG: Passwords changed.
	27/01/2025 09:51:07 DEBUG: Changing API passwords.
	27/01/2025 09:51:13 INFO: Initializing Wazuh dashboard web application.
	27/01/2025 09:51:15 INFO: Wazuh dashboard web application initialized.
	27/01/2025 09:51:15 INFO: --- Summary ---
	27/01/2025 09:51:15 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
	    User: admin
	    Password: xxxx
	27/01/2025 09:51:15 DEBUG: Restoring Wazuh repository.
	27/01/2025 09:51:15 INFO: Installation finished.
	```
	
	We can see that the URL now is:
	```
	Filebeat Wazuh template is: https://raw.githubusercontent.com/wazuh/wazuh/v4.11.0-alpha1/extensions/elasticsearch/7.x/wazuh-template.json
	```
	
    ![Screenshot_20250127_112622](https://github.com/user-attachments/assets/76f5031c-463a-451b-93e9-7597fdeda965)

	
	</details>



- Validating the functionality of `check_FilebeatURL()`.

	<details><summary>Function tests</summary>
	
	Without last_stage and correct branch (use the brach):
	```console
	$ bash check_filebeat_url.sh
	Source branch: 4.11.0
	Filebeat template: https://raw.githubusercontent.com/wazuh/wazuh/4.11.0/extensions/elasticsearch/7.x/wazuh-template.json
	```
	
	With incorrect URL (use main branch):
	```console
	$ bash check_filebeat_url.sh
	Using Filebeat template from master branch.
	Source branch: v4.11.o
	Filebeat template: https://raw.githubusercontent.com/wazuh/wazuh/main/extensions/elasticsearch/7.x/wazuh-template.json
	```
	
	</details>

## Related issue

- #221 
