### PR TITLE
Remove alpha1 stage in installVariables after retag

### DIFF
--- a/install_functions/installVariables.sh
+++ b/install_functions/installVariables.sh
@@ -12,7 +12,7 @@ readonly wazuh_version="4.11.0"
 readonly filebeat_version="7.10.2"
 readonly wazuh_install_vesion="0.1"
 source_branch="v${wazuh_version}"
-last_stage="alpha1"
+last_stage=""
 
 repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"
 repobaseurl="https://packages.wazuh.com/4.x"


### PR DESCRIPTION
# Description

This PR aims to remove the alpha1 stage after retag `v4.11.0-alpha1`