### PR TITLE
Change master branch references to main

### DIFF
--- a/.github/workflows/Test_installation_assistant.yml
+++ b/.github/workflows/Test_installation_assistant.yml
@@ -27,7 +27,7 @@ on:
       AUTOMATION_REFERENCE:
         description: 'Branch or tag of the wazuh-automation repository'
         required: true
-        default: 'master'
+        default: 'main'
       SYSTEMS:
         description: 'Operating Systems (list of comma-separated quoted strings enclosed in square brackets)'
         required: true

--- a/.github/workflows/Test_installation_assistant_distributed.yml
+++ b/.github/workflows/Test_installation_assistant_distributed.yml
@@ -27,7 +27,7 @@ on:
       AUTOMATION_REFERENCE:
         description: 'Branch or tag of the wazuh-automation repository'
         required: true
-        default: 'master'
+        default: 'main'
       SYSTEMS:
         description: 'Operating Systems (list of comma-separated quoted strings enclosed in square brackets)'
         required: true

--- a/builder.sh
+++ b/builder.sh
@@ -245,7 +245,7 @@ function builder_main() {
 function checkDistDetectURL() {
 
     urls=("https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/src/init/dist-detect.sh"
-          "https://raw.githubusercontent.com/wazuh/wazuh/master/src/init/dist-detect.sh")
+          "https://raw.githubusercontent.com/wazuh/wazuh/main/src/init/dist-detect.sh")
 
     for url in "${urls[@]}"; do
         eval "curl -s -o /dev/null '${url}' --retry 5 --retry-delay 5 --max-time 300 --fail"

--- a/install_functions/checks.sh
+++ b/install_functions/checks.sh
@@ -492,8 +492,8 @@ function checks_filebeatURL() {
         filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
     fi
 
-    # URL using master branch
-    new_filebeat_url="${filebeat_wazuh_template/${source_branch}/master}"
+    # URL using main branch
+    new_filebeat_url="${filebeat_wazuh_template/${source_branch}/main}"
     
     response=$(curl -I --write-out '%{http_code}' --silent --output /dev/null $filebeat_wazuh_template)
     if [ "${response}" != "200" ]; then
@@ -503,7 +503,7 @@ function checks_filebeatURL() {
         if [ "${response}" != "200" ]; then
             common_logger -e "Error: Could not get the Filebeat Wazuh template."
         else
-            common_logger "Using Filebeat template from master branch."
+            common_logger "Using Filebeat template from main branch."
             filebeat_wazuh_template="${new_filebeat_url}"
         fi
     fi


### PR DESCRIPTION
# Description

This PR aims to update references to `master` in the `main` branch to align with modern naming conventions and inclusive practices.

> [!Note]
> There are additional occurrences of the word `master`, but they refer to the manager's master node.

## Related issue

- #231 