### PR TITLE
Changed uninstall variables names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Changed uninstall variables names. ([#259](https://github.com/wazuh/wazuh-installation-assistant/pull/259))
 
 ### Deleted
 

--- a/install_functions/installCommon.sh
+++ b/install_functions/installCommon.sh
@@ -229,11 +229,11 @@ function installCommon_createInstallFiles() {
         elif [ "${sys_type}" == "apt-get" ]; then
             installCommon_aptInstallList "${dep}"
         fi
-        
+
         if [ "${#not_installed[@]}" -gt 0 ]; then
             wia_dependencies_installed+=("${dep}")
         fi
-        
+
         if [ -n "${configurations}" ]; then
             cert_checkOpenSSL
         fi
@@ -414,7 +414,7 @@ function installCommon_installPrerequisites() {
             fi
         fi
     elif [ "${sys_type}" == "apt-get" ]; then
-        if [ -z "${offline_install}" ]; then 
+        if [ -z "${offline_install}" ]; then
             eval "apt-get update -q ${debug}"
         fi
         if [ "${1}" == "AIO" ]; then
@@ -620,15 +620,15 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-manager -y ${debug}"
-                eval "rpm -q wazuh-manager --quiet && manager_installed=1"
+                eval "rpm -q wazuh-manager --quiet && wazuh_failed_uninstall=1"
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge wazuh-manager -y ${debug}"
-            manager_installed=$(apt list --installed 2>/dev/null | grep wazuh-manager)
+            wazuh_failed_uninstall=$(apt list --installed 2>/dev/null | grep wazuh-manager)
         fi
 
-        if [ -n "${manager_installed}" ]; then
+        if [ -n "${wazuh_failed_uninstall}" ]; then
             common_logger -w "The Wazuh manager package could not be removed."
         else
             common_logger "Wazuh manager removed."
@@ -646,15 +646,15 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-indexer -y ${debug}"
-                eval "rpm -q wazuh-indexer --quiet && indexer_installed=1"
+                eval "rpm -q wazuh-indexer --quiet && indexer_failed_uninstall=1"
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge wazuh-indexer -y ${debug}"
-            indexer_installed=$(apt list --installed 2>/dev/null | grep wazuh-indexer)
+            indexer_failed_uninstall=$(apt list --installed 2>/dev/null | grep wazuh-indexer)
         fi
 
-        if [ -n "${indexer_installed}" ]; then
+        if [ -n "${indexer_failed_uninstall}" ]; then
             common_logger -w "The Wazuh indexer package could not be removed."
         else
             common_logger "Wazuh indexer removed."
@@ -673,15 +673,15 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove filebeat -y ${debug}"
-                eval "rpm -q filebeat --quiet && filebeat_installed=1"
+                eval "rpm -q filebeat --quiet && filebeat_failed_uninstall=1"
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge filebeat -y ${debug}"
-            filebeat_installed=$(apt list --installed 2>/dev/null | grep filebeat)
+            filebeat_failed_uninstall=$(apt list --installed 2>/dev/null | grep filebeat)
         fi
 
-        if [ -n "${filebeat_installed}" ]; then
+        if [ -n "${filebeat_failed_uninstall}" ]; then
             common_logger -w "The Filebeat package could not be removed."
         else
             common_logger "Filebeat removed."
@@ -700,15 +700,15 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-dashboard -y ${debug}"
-                eval "rpm -q wazuh-dashboard --quiet && dashboard_installed=1"
+                eval "rpm -q wazuh-dashboard --quiet && dashboard_failed_uninstall=1"
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge wazuh-dashboard -y ${debug}"
-            dashboard_installed=$(apt list --installed 2>/dev/null | grep wazuh-dashboard)
+            dashboard_failed_uninstall=$(apt list --installed 2>/dev/null | grep wazuh-dashboard)
         fi
 
-        if [ -n "${dashboard_installed}" ]; then
+        if [ -n "${dashboard_failed_uninstall}" ]; then
             common_logger -w "The Wazuh dashboard package could not be removed."
         else
             common_logger "Wazuh dashboard removed."


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-installation-assistant/issues/258

The error occurred because in the control process, after removing the components, variables already set were reused. In the case of RPM, this generates a problem since the variable is set after the validation that the package is installed. When it is not installed, the variables are set to 1. This does not happen in APT because the variable is defined with the output of the control command.

The names of the variables are modified so that the uninstallation control has new variables and are set in case the package exists after uninstalling.


## Test

### CentOS 7:

```console
[root@centos-7 ~]# bash /home/vagrant/wazuh-install.sh -u
28/02/2025 14:59:33 INFO: Starting Wazuh installation assistant. Wazuh version: 4.11.1 (x86_64/AMD64)
28/02/2025 14:59:33 INFO: Verbose logging redirected to /var/log/wazuh-install.log
28/02/2025 14:59:34 INFO: Removing Wazuh manager.
28/02/2025 14:59:52 INFO: Wazuh manager removed.
28/02/2025 14:59:52 INFO: Removing Wazuh indexer.
28/02/2025 14:59:53 INFO: Wazuh indexer removed.
28/02/2025 14:59:53 INFO: Removing Filebeat.
28/02/2025 14:59:54 INFO: Filebeat removed.
28/02/2025 14:59:54 INFO: Removing Wazuh dashboard.
28/02/2025 15:00:03 INFO: Wazuh dashboard removed.
```

### RHEL 9:

```console
[root@cbordon-3843 ~]# sudo bash /home/vagrant/wazuh-install.sh -a -d pre-release
28/02/2025 14:58:57 INFO: Starting Wazuh installation assistant. Wazuh version: 4.11.1 (x86_64/AMD64)
28/02/2025 14:58:57 INFO: Verbose logging redirected to /var/log/wazuh-install.log
28/02/2025 14:58:59 INFO: Using Filebeat template from master branch.
28/02/2025 14:58:59 INFO: Verifying that your system meets the recommended minimum hardware requirements.
28/02/2025 14:58:59 INFO: Wazuh web interface port will be 443.
28/02/2025 14:58:59 WARNING: The system has Firewalld enabled. Please ensure that traffic is allowed on these ports: 1515, 1514, 443.
28/02/2025 14:59:01 INFO: Wazuh development repository added.
28/02/2025 14:59:01 INFO: --- Configuration files ---
28/02/2025 14:59:01 INFO: Generating configuration files.
28/02/2025 14:59:01 INFO: Generating the root certificate.
28/02/2025 14:59:01 INFO: Generating Admin certificates.
28/02/2025 14:59:01 INFO: Generating Wazuh indexer certificates.
28/02/2025 14:59:02 INFO: Generating Filebeat certificates.
28/02/2025 14:59:02 INFO: Generating Wazuh dashboard certificates.
28/02/2025 14:59:02 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
28/02/2025 14:59:02 INFO: --- Wazuh indexer ---
28/02/2025 14:59:02 INFO: Starting Wazuh indexer installation.
28/02/2025 15:01:38 INFO: Wazuh indexer installation finished.
28/02/2025 15:01:38 INFO: Wazuh indexer post-install configuration finished.
28/02/2025 15:01:38 INFO: Starting service wazuh-indexer.
28/02/2025 15:01:48 INFO: wazuh-indexer service started.
28/02/2025 15:01:48 INFO: Initializing Wazuh indexer cluster security settings.
28/02/2025 15:01:52 INFO: Wazuh indexer cluster security configuration initialized.
28/02/2025 15:01:52 INFO: Wazuh indexer cluster initialized.
28/02/2025 15:01:52 INFO: --- Wazuh server ---
28/02/2025 15:01:52 INFO: Starting the Wazuh manager installation.
28/02/2025 15:03:14 INFO: Wazuh manager installation finished.
28/02/2025 15:03:14 INFO: Wazuh manager vulnerability detection configuration finished.
28/02/2025 15:03:14 INFO: Starting service wazuh-manager.
28/02/2025 15:03:26 INFO: wazuh-manager service started.
28/02/2025 15:03:26 INFO: Starting Filebeat installation.
28/02/2025 15:04:16 INFO: Filebeat installation finished.
28/02/2025 15:04:22 INFO: Filebeat post-install configuration finished.
28/02/2025 15:04:22 INFO: Starting service filebeat.
28/02/2025 15:04:23 INFO: filebeat service started.
28/02/2025 15:04:23 INFO: --- Wazuh dashboard ---
28/02/2025 15:04:23 INFO: Starting Wazuh dashboard installation.
28/02/2025 15:06:01 INFO: Wazuh dashboard installation finished.
28/02/2025 15:06:01 INFO: Wazuh dashboard post-install configuration finished.
28/02/2025 15:06:01 INFO: Starting service wazuh-dashboard.
28/02/2025 15:06:01 INFO: wazuh-dashboard service started.
28/02/2025 15:06:01 INFO: Updating the internal users.
28/02/2025 15:06:04 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
28/02/2025 15:06:12 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
28/02/2025 15:06:40 INFO: Initializing Wazuh dashboard web application.
28/02/2025 15:06:40 INFO: Wazuh dashboard web application initialized.
28/02/2025 15:06:40 INFO: --- Summary ---
28/02/2025 15:06:40 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: WBF*0srEMn+X1aUvQEWjGy9avv+HEb09
28/02/2025 15:06:40 INFO: Installation finished.

```

```console

[root@cbordon-3843 ~]# sudo bash /home/vagrant/wazuh-install.sh -u
28/02/2025 15:07:34 INFO: Starting Wazuh installation assistant. Wazuh version: 4.11.1 (x86_64/AMD64)
28/02/2025 15:07:34 INFO: Verbose logging redirected to /var/log/wazuh-install.log
28/02/2025 15:07:34 INFO: Removing Wazuh manager.
28/02/2025 15:07:51 INFO: Wazuh manager removed.
28/02/2025 15:07:51 INFO: Removing Wazuh indexer.
28/02/2025 15:07:52 INFO: Wazuh indexer removed.
28/02/2025 15:07:52 INFO: Removing Filebeat.
28/02/2025 15:07:53 INFO: Filebeat removed.
28/02/2025 15:07:53 INFO: Removing Wazuh dashboard.
28/02/2025 15:08:00 INFO: Wazuh dashboard removed.

```


### Ubuntu 22.04:

```console
root@cbordon-3132:~# bash /home/vagrant/wazuh-install.sh -a -d pre-release
28/02/2025 15:13:19 INFO: Starting Wazuh installation assistant. Wazuh version: 4.11.1 (x86_64/AMD64)
28/02/2025 15:13:19 INFO: Verbose logging redirected to /var/log/wazuh-install.log
28/02/2025 15:13:36 INFO: Using Filebeat template from master branch.
28/02/2025 15:13:36 INFO: Verifying that your system meets the recommended minimum hardware requirements.
28/02/2025 15:13:36 INFO: Wazuh web interface port will be 443.
28/02/2025 15:13:41 INFO: --- Dependencies ----
28/02/2025 15:13:41 INFO: Installing apt-transport-https.
28/02/2025 15:13:46 INFO: Installing debhelper.
28/02/2025 15:14:09 INFO: Wazuh development repository added.
28/02/2025 15:14:09 INFO: --- Configuration files ---
28/02/2025 15:14:09 INFO: Generating configuration files.
28/02/2025 15:14:10 INFO: Generating the root certificate.
28/02/2025 15:14:10 INFO: Generating Admin certificates.
28/02/2025 15:14:10 INFO: Generating Wazuh indexer certificates.
28/02/2025 15:14:10 INFO: Generating Filebeat certificates.
28/02/2025 15:14:11 INFO: Generating Wazuh dashboard certificates.
28/02/2025 15:14:11 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
28/02/2025 15:14:11 INFO: --- Wazuh indexer ---
28/02/2025 15:14:11 INFO: Starting Wazuh indexer installation.
28/02/2025 15:15:53 INFO: Wazuh indexer installation finished.
28/02/2025 15:15:53 INFO: Wazuh indexer post-install configuration finished.
28/02/2025 15:15:53 INFO: Starting service wazuh-indexer.
28/02/2025 15:16:05 INFO: wazuh-indexer service started.
28/02/2025 15:16:05 INFO: Initializing Wazuh indexer cluster security settings.
28/02/2025 15:16:08 INFO: Wazuh indexer cluster security configuration initialized.
28/02/2025 15:16:08 INFO: Wazuh indexer cluster initialized.
28/02/2025 15:16:08 INFO: --- Wazuh server ---
28/02/2025 15:16:08 INFO: Starting the Wazuh manager installation.
28/02/2025 15:17:36 INFO: Wazuh manager installation finished.
28/02/2025 15:17:36 INFO: Wazuh manager vulnerability detection configuration finished.
28/02/2025 15:17:36 INFO: Starting service wazuh-manager.
28/02/2025 15:17:51 INFO: wazuh-manager service started.
28/02/2025 15:17:51 INFO: Starting Filebeat installation.
28/02/2025 15:18:25 INFO: Filebeat installation finished.
28/02/2025 15:18:28 INFO: Filebeat post-install configuration finished.
28/02/2025 15:18:28 INFO: Starting service filebeat.
28/02/2025 15:18:28 INFO: filebeat service started.
28/02/2025 15:18:28 INFO: --- Wazuh dashboard ---
28/02/2025 15:18:28 INFO: Starting Wazuh dashboard installation.
28/02/2025 15:19:40 INFO: Wazuh dashboard installation finished.
28/02/2025 15:19:40 INFO: Wazuh dashboard post-install configuration finished.
28/02/2025 15:19:40 INFO: Starting service wazuh-dashboard.
28/02/2025 15:19:40 INFO: wazuh-dashboard service started.
28/02/2025 15:19:42 INFO: Updating the internal users.
28/02/2025 15:19:45 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
28/02/2025 15:19:55 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
28/02/2025 15:20:22 INFO: Initializing Wazuh dashboard web application.
28/02/2025 15:20:23 INFO: Wazuh dashboard web application initialized.
28/02/2025 15:20:23 INFO: --- Summary ---
28/02/2025 15:20:23 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: 3zovFK0jIy.1dmeuBaTQnFtoe4f?PHHe
28/02/2025 15:20:23 INFO: Installation finished.
```

```console
root@cbordon-3132:~# bash /home/vagrant/wazuh-install.sh -u
28/02/2025 15:20:28 INFO: Starting Wazuh installation assistant. Wazuh version: 4.11.1 (x86_64/AMD64)
28/02/2025 15:20:28 INFO: Verbose logging redirected to /var/log/wazuh-install.log
28/02/2025 15:20:31 INFO: Removing Wazuh manager.
28/02/2025 15:20:40 INFO: Wazuh manager removed.
28/02/2025 15:20:40 INFO: Removing Wazuh indexer.
28/02/2025 15:20:45 INFO: Wazuh indexer removed.
28/02/2025 15:20:45 INFO: Removing Filebeat.
28/02/2025 15:20:49 INFO: Filebeat removed.
28/02/2025 15:20:49 INFO: Removing Wazuh dashboard.
28/02/2025 15:20:56 INFO: Wazuh dashboard removed.
```