### PR TITLE
Removed last_stage var from 4.11.1 rc1

### DIFF
--- a/install_functions/installVariables.sh
+++ b/install_functions/installVariables.sh
@@ -12,7 +12,7 @@ readonly wazuh_version="4.11.1"
 readonly filebeat_version="7.10.2"
 readonly wazuh_install_vesion="0.1"
 source_branch="v${wazuh_version}"
-last_stage="rc1"
+last_stage=""
 
 repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"
 repobaseurl="https://packages.wazuh.com/4.x"


### PR DESCRIPTION
Removed last_stage var from 4.11.1 rc1