### PR TITLE
Fix `wazuh_major` version string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Fix wazuh_major version string ([#272](https://github.com/wazuh/wazuh-installation-assistant/pull/272))
 
 ### Deleted
 

--- a/install_functions/installVariables.sh
+++ b/install_functions/installVariables.sh
@@ -7,7 +7,7 @@
 # Foundation.
 
 ## Package vars
-readonly wazuh_major="4.13
+readonly wazuh_major="4.13"
 readonly wazuh_version="4.13.0"
 readonly filebeat_version="7.10.2"
 readonly wazuh_install_vesion="0.1"


### PR DESCRIPTION
# Description

While https://github.com/wazuh/wazuh/issues/28566, the `wazuh_major` variable was left unencapsulated, preventing the installation assistant from being used.

This PR aims to fix this variable.