### PR TITLE
Fixed offline download for Filebeat package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed offline download for Filebeat package. ([#301](https://github.com/wazuh/wazuh-installation-assistant/pull/301))
 - Fixed handling of hash.sh script output in Password Tool. ([#290](https://github.com/wazuh/wazuh-installation-assistant/pull/290))
 
 ## [4.11.2]

--- a/install_functions/installVariables.sh
+++ b/install_functions/installVariables.sh
@@ -44,12 +44,12 @@ readonly apt_lockfile="/var/lib/dpkg/lock"
 ## Offline Installation vars
 readonly base_dest_folder="wazuh-offline"
 manager_deb_base_url="${base_url}/apt/pool/main/w/wazuh-manager"
-readonly filebeat_deb_base_url="${base_url}/apt/pool/main/f/filebeat"
+filebeat_deb_base_url="${base_url}/apt/pool/main/f/filebeat"
 
 indexer_deb_base_url="${base_url}/apt/pool/main/w/wazuh-indexer"
 dashboard_deb_base_url="${base_url}/apt/pool/main/w/wazuh-dashboard"
 manager_rpm_base_url="${base_url}/yum"
-readonly filebeat_rpm_base_url="${base_url}/yum"
+filebeat_rpm_base_url="${base_url}/yum"
 
 indexer_rpm_base_url="${base_url}/yum"
 dashboard_rpm_base_url="${base_url}/yum"

--- a/install_functions/wazuh-offline-installation.sh
+++ b/install_functions/wazuh-offline-installation.sh
@@ -12,13 +12,13 @@
 function offline_checkPrerequisites(){
 
     dependencies=( "${@}" )
-    if [ $1 == "wia_offline_dependencies" ]; then   
-        dependencies=( "${@:2}" ) 
+    if [ $1 == "wia_offline_dependencies" ]; then
+        dependencies=( "${@:2}" )
         common_logger "Checking dependencies for Wazuh installation assistant."
     else
         common_logger "Checking prerequisites for Offline installation."
     fi
-    
+
     for dep in "${dependencies[@]}"; do
         if [ "${sys_type}" == "yum" ]; then
             eval "yum list installed 2>/dev/null | grep -q -E ^"${dep}"\\."
@@ -75,9 +75,9 @@ function offline_extractFiles() {
     )
 
     if [ "${sys_type}" == "apt-get" ]; then
-        required_files+=("${offline_packages_path}/filebeat-oss-*.deb" "${offline_packages_path}/wazuh-dashboard_*.deb" "${offline_packages_path}/wazuh-indexer_*.deb" "${offline_packages_path}/wazuh-manager_*.deb")
+        required_files+=("${offline_packages_path}/filebeat_*.deb" "${offline_packages_path}/wazuh-dashboard_*.deb" "${offline_packages_path}/wazuh-indexer_*.deb" "${offline_packages_path}/wazuh-manager_*.deb")
     elif [ "${sys_type}" == "rpm" ]; then
-        required_files+=("${offline_packages_path}/filebeat-oss-*.rpm" "${offline_packages_path}/wazuh-dashboard_*.rpm" "${offline_packages_path}/wazuh-indexer_*.rpm" "${offline_packages_path}/wazuh-manager_*.rpm")
+        required_files+=("${offline_packages_path}/filebeat-*.rpm" "${offline_packages_path}/wazuh-dashboard_*.rpm" "${offline_packages_path}/wazuh-indexer_*.rpm" "${offline_packages_path}/wazuh-manager_*.rpm")
     fi
 
     for file in "${required_files[@]}"; do


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-installation-assistant/issues/298

## Description

The Filebeat offline package download process had to be adapted following changes in the nomenclature of these packages.

## Tests

- Amazon Linux 2023 x86_64 https://github.com/wazuh/wazuh-installation-assistant/issues/298#issuecomment-2789501771
- Amazon Linux 2023 aarch64 https://github.com/wazuh/wazuh-installation-assistant/issues/298#issuecomment-2787462069
- Ubuntu 22.04 amd64 https://github.com/wazuh/wazuh-installation-assistant/issues/298#issuecomment-2789660805
- Ubuntu 22.04 arm64 https://github.com/wazuh/wazuh-installation-assistant/issues/298#issuecomment-2789635832