### PR TITLE
Fixed Wazuh Dashboard API host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed Wazuh Dashboard API host. ([#681](https://github.com/wazuh/wazuh-installation-assistant/pull/681))
 - Fixed offline one liner quickstart aio hang during files validation. ([#680](https://github.com/wazuh/wazuh-installation-assistant/pull/680))
 - Fix YAML Parser to Accept Multiple Indentation Formats ([#631](https://github.com/wazuh/wazuh-installation-assistant/pull/631))
 - Update Indexer cluster security initialization message ([#563](https://github.com/wazuh/wazuh-installation-assistant/pull/563))

--- a/install_functions/dashboard.sh
+++ b/install_functions/dashboard.sh
@@ -11,7 +11,7 @@ function dashboard_obtainNodeIp() {
     if [ -z "${dashboard_ip}" ]; then
         if [ "${AIO}" ]; then
             dashboard_ip="${dashboard_node_ips[0]}"
-        else 
+        else
             for i in "${!dashboard_node_names[@]}"; do
                 if [[ "${dashboard_node_names[i]}" == "${dashname}" ]]; then
                     dashboard_ip=${dashboard_node_ips[i]};
@@ -46,11 +46,15 @@ function dashboard_configure() {
     if [ -n "${AIO}" ]; then
         wazuh_api_address=${manager_node_ips[0]}
     else
-        for i in "${!manager_node_types[@]}"; do
-            if [[ "${manager_node_types[i]}" == "master" ]]; then
-                wazuh_api_address=${manager_node_ips[i]}
-            fi
-        done
+        if [ -n "${manager_node_types[*]}" ]; then
+            for i in "${!manager_node_types[@]}"; do
+                if [[ "${manager_node_types[i]}" == "master" ]]; then
+                    wazuh_api_address=${manager_node_ips[i]}
+                fi
+            done
+        else
+            wazuh_api_address=${manager_node_ips[0]}
+        fi
     fi
     eval "sed -i 's|url:.*|url: https://${wazuh_api_address}|' /etc/wazuh-dashboard/opensearch_dashboards.yml ${debug}"
 
@@ -129,7 +133,7 @@ function dashboard_install() {
         fi
         installCommon_aptInstall "${package_file}"
     fi
-    
+
     common_checkInstalled
     if [  "$install_result" != 0  ] || [ -z "${dashboard_installed}" ]; then
         common_logger -e "Wazuh dashboard installation failed."

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -147,6 +147,15 @@ class TestDashboardConfigure:
         result = self._run(extra_env={"AIO": "1"})
         assert_success(result)
 
+    def test_success_single_manager_no_node_type(self):
+        """When there is a single manager without node_type, wazuh_api_address should default to manager_node_ips[0]."""
+        result = self._run(
+            extra_env={
+                "manager_node_types": "",
+            }
+        )
+        assert_success(result)
+
     def test_success_multi_indexer_nodes(self):
         result = self._run(
             extra_env={


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-installation-assistant/issues/654

## Description

When deploying with a single manager node (no node_type specified in config.yml), manager_node_types is empty, so the for loop never executes and wazuh_api_address stays empty — resulting in url: https:// with no IP.

Fix: Added a check for manager_node_types being empty. When it is (single manager, no node_type), it falls back to manager_node_ips[0], matching the AIO behavior. When manager_node_types is populated (multi-node cluster), it keeps the existing logic of finding the master node.

## Test

### Offline aio https://github.com/wazuh/wazuh-installation-assistant/issues/654#issuecomment-4216255369

### Online aio https://github.com/wazuh/wazuh-installation-assistant/issues/654#issuecomment-4215926707

### Online distributed https://github.com/wazuh/wazuh-installation-assistant/issues/654#issuecomment-4216585274