### PR TITLE
Added offline installation documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added offline installation documentation ([#683](https://github.com/wazuh/wazuh-installation-assistant/pull/683))
 - Add unit and integration test ([#630](https://github.com/wazuh/wazuh-installation-assistant/pull/630))
 - Add DNS support to the certs-tool ([#634](https://github.com/wazuh/wazuh-installation-assistant/pull/634))
 - Add documentation for Installation Assistant Tools in 5.0 ([#583](https://github.com/wazuh/wazuh-installation-assistant/pull/583))

--- a/docs/guide/offline-download-packages/offline-download-packages.md
+++ b/docs/guide/offline-download-packages/offline-download-packages.md
@@ -1,0 +1,84 @@
+# Offline download packages
+
+## Prerequisites
+
+There are some packages that need to be installed in the target system where the offline installation will be done. These are:
+
+- `curl`
+- `tar`
+- `setcap`
+- `gnupg` (for some Debian-based systems)
+
+## Download the packages
+
+### 1. Download the Wazuh Installation Assistant
+
+```bash
+curl -sO https://packages.wazuh.com/production/5.x/wazuh-install.sh
+chmod 744 wazuh-install.sh
+```
+
+### 2. Download packages by architecture using the installation assistant
+
+#### For RPM
+
+##### x86_64
+
+```bash
+./wazuh-install.sh -dw rpm -da x86_64
+```
+
+##### aarch64
+
+```bash
+./wazuh-install.sh -dw rpm -da aarch64
+```
+
+#### For DEB
+
+##### amd64
+
+```bash
+./wazuh-install.sh -dw deb -da amd64
+```
+
+##### arm64
+
+```bash
+./wazuh-install.sh -dw deb -da arm64
+```
+
+### 3. Download the certificates configuration file
+
+```bash
+curl -sO https://packages.wazuh.com/production/5.x/config.yml
+```
+
+### 4. Edit `config.yml` to prepare the certificates creation
+
+- If you are performning an all-in-one deployment, replace the `"<indexer-node-ip>"`, `"<wazuh-manager-ip>"`, and `"<dashboard-node-ip>"` with `127.0.0.1`.
+- If you are performing a distributed deployment, replace the node names and IP values with the corresponding names and IP addresses. You need to do this for all the Wazuh server, Wazuh indexer, and Wazuh dashboard nodes. Add as many node fields as needed.
+
+### 5. Create the certificates
+
+Run the following command in order to create the certificates using the installation assistant script.
+
+```bash
+./wazuh-install.sh -g
+```
+
+### 6. Copy the necessary files to the final host
+
+Copy the certificates, the packages and the installation assistant to the final host where the offline installation will be carried out.
+You can use `scp` to complete this task.
+
+- `wazuh-install.sh`
+- `wazuh-offline.tar.gz`
+- `wazuh-install-files.tar`
+
+### Next steps
+
+Now, you can continue with the installation of the Wazuh components:
+
+- Installing using the [installation assistant](/docs/guide/offline-installation-assistant-deployments/offline-all-in-one.md).
+- Installing [step-by-step](/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md).

--- a/docs/guide/offline-download-packages/offline-download-packages.md
+++ b/docs/guide/offline-download-packages/offline-download-packages.md
@@ -16,8 +16,8 @@ There are some packages that need to be installed in the target system where the
 ### 1. Download the Wazuh Installation Assistant
 
 ```bash
-curl -sO https://packages.wazuh.com/production/5.x/wazuh-install.sh
-chmod 744 wazuh-install.sh
+curl -sO https://packages.wazuh.com/production/5.x/wazuh-install-5.0.0-1.sh
+chmod 744 wazuh-install-5.0.0-1.sh
 ```
 
 ### 2. Download packages by architecture using the installation assistant
@@ -27,13 +27,13 @@ chmod 744 wazuh-install.sh
 ##### x86_64
 
 ```bash
-./wazuh-install.sh -dw rpm -da x86_64
+./wazuh-install-5.0.0-1.sh -dw rpm -da x86_64
 ```
 
 ##### aarch64
 
 ```bash
-./wazuh-install.sh -dw rpm -da aarch64
+./wazuh-install-5.0.0-1.sh -dw rpm -da aarch64
 ```
 
 #### For DEB
@@ -41,19 +41,19 @@ chmod 744 wazuh-install.sh
 ##### amd64
 
 ```bash
-./wazuh-install.sh -dw deb -da amd64
+./wazuh-install-5.0.0-1.sh -dw deb -da amd64
 ```
 
 ##### arm64
 
 ```bash
-./wazuh-install.sh -dw deb -da arm64
+./wazuh-install-5.0.0-1.sh -dw deb -da arm64
 ```
 
 ### 3. Download the certificates configuration file
 
 ```bash
-curl -sO https://packages.wazuh.com/production/5.x/config.yml
+curl -s -o config.yml https://packages.wazuh.com/production/5.x/config-5.0.0-1.yml
 ```
 
 ### 4. Edit `config.yml` to prepare the certificates creation
@@ -66,7 +66,7 @@ curl -sO https://packages.wazuh.com/production/5.x/config.yml
 Run the following command in order to create the certificates using the installation assistant script.
 
 ```bash
-./wazuh-install.sh -g
+./wazuh-install-5.0.0-1.sh -g
 ```
 
 ### 6. Copy the necessary files to the final host
@@ -74,7 +74,7 @@ Run the following command in order to create the certificates using the installa
 Copy the certificates, the packages and the installation assistant to the final host where the offline installation will be carried out.
 You can use `scp` to complete this task.
 
-- `wazuh-install.sh`
+- `wazuh-install-5.0.0-1.sh`
 - `wazuh-offline.tar.gz`
 - `wazuh-install-files.tar`
 

--- a/docs/guide/offline-download-packages/offline-download-packages.md
+++ b/docs/guide/offline-download-packages/offline-download-packages.md
@@ -9,6 +9,8 @@ There are some packages that need to be installed in the target system where the
 - `setcap`
 - `gnupg` (for some Debian-based systems)
 
+---
+
 ## Download the packages
 
 ### 1. Download the Wazuh Installation Assistant
@@ -76,9 +78,11 @@ You can use `scp` to complete this task.
 - `wazuh-offline.tar.gz`
 - `wazuh-install-files.tar`
 
-### Next steps
+---
+
+## Next steps
 
 Now, you can continue with the installation of the Wazuh components:
 
-- Installing using the [installation assistant](/docs/guide/offline-installation-assistant-deployments/offline-all-in-one.md).
+- Installing using the [installation assistant](/docs/guide/offline-installation-assistant-deployments/offline-assisted-install.md).
 - Installing [step-by-step](/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md).

--- a/docs/guide/offline-installation-assistant-deployments/offline-assisted-install.md
+++ b/docs/guide/offline-installation-assistant-deployments/offline-assisted-install.md
@@ -28,14 +28,14 @@ For the single-node offline installation, you need to have the following files i
 
 - `wazuh-install-files.tar`
 - `wazuh-offline.tar.gz`
-- `wazuh-install.sh`
+- `wazuh-install-5.0.0-1.sh`
 
 ### Installation
 
 To perform the offline installation with the `--offline-installation` flag of Wazuh manager on a single-node using the assisted method, run:
 
 ```bash
-bash wazuh-install.sh --offline-installation -a
+bash wazuh-install-5.0.0-1.sh --offline-installation -a
 ```
 
 Once the assistant finishes the installation, the output shows the access credentials and a message that confirms that the installation was successful:
@@ -84,7 +84,7 @@ The following dependencies must be installed on the Wazuh indexer nodes:
 1. Run the multi-node assisted method with the `--offline-installation` flag to perform an offline installation. Use the option `--wazuh-indexer` and the node name to install and configure the Wazuh indexer. The node name must be the same one used in `config.yml` for the initial configuration, for example, `indexer`.
 
     ```bash
-    bash wazuh-install.sh --offline-installation --wazuh-indexer indexer
+    bash wazuh-install-5.0.0-1.sh --offline-installation --wazuh-indexer indexer
     ```
 
     Repeat this step for every Wazuh indexer node in your cluster. Then proceed with initializing your multi-node cluster in the next step.
@@ -92,7 +92,7 @@ The following dependencies must be installed on the Wazuh indexer nodes:
 2. Run the Wazuh assisted installation option `--start-cluster` on any Wazuh indexer node to load the new certificates information and start the cluster.
 
     ```bash
-    bash wazuh-install.sh --offline-installation --start-cluster
+    bash wazuh-install-5.0.0-1.sh --offline-installation --start-cluster
     ```
 
     > **Note:** You only have to initialize the cluster once. There is no need to run this command on every node.
@@ -150,7 +150,7 @@ The following dependencies must be installed on the Wazuh indexer nodes:
 Run the assisted method with `--offline-installation` to perform an offline installation. Use the option `--wazuh-manager` followed by the node name to install the Wazuh manager. The node name must be the same one used in `config.yml` for the initial configuration, for example, `manager`.
 
 ```bash
-bash wazuh-install.sh --offline-installation --wazuh-manager manager
+bash wazuh-install-5.0.0-1.sh --offline-installation --wazuh-manager manager
 ```
 
 Your Wazuh manager is now successfully installed. Repeat this step on every Wazuh manager node.
@@ -174,7 +174,7 @@ The following dependencies must be installed on the Wazuh dashboard node:
 1. Run the assisted method with `--offline-installation` to perform an offline installation. Use the option `--wazuh-dashboard` and the node name to install and configure the Wazuh dashboard. The node name must be the same one used in `config.yml` for the initial configuration, for example, `dashboard`.
 
     ```bash
-    bash wazuh-install.sh --offline-installation --wazuh-dashboard dashboard
+    bash wazuh-install-5.0.0-1.sh --offline-installation --wazuh-dashboard dashboard
     ```
 
 The TCP port for the Wazuh web user interface (dashboard) is 443.

--- a/docs/guide/offline-installation-assistant-deployments/offline-assisted-install.md
+++ b/docs/guide/offline-installation-assistant-deployments/offline-assisted-install.md
@@ -32,7 +32,7 @@ For the single-node offline installation, you need to have the following files i
 
 ### Installation
 
-To perform the offline installation with the `--offline-installation` flag of Wazuh server on a single-node using the assisted method, run:
+To perform the offline installation with the `--offline-installation` flag of Wazuh manager on a single-node using the assisted method, run:
 
 ```bash
 bash wazuh-install.sh --offline-installation -a
@@ -153,7 +153,7 @@ Run the assisted method with `--offline-installation` to perform an offline inst
 bash wazuh-install.sh --offline-installation --wazuh-manager manager
 ```
 
-Your Wazuh server is now successfully installed. Repeat this step on every Wazuh server node.
+Your Wazuh manager is now successfully installed. Repeat this step on every Wazuh manager node.
 
 ### Installing the Wazuh dashboard
 

--- a/docs/guide/offline-installation-assistant-deployments/offline-assisted-install.md
+++ b/docs/guide/offline-installation-assistant-deployments/offline-assisted-install.md
@@ -1,0 +1,207 @@
+# Offline install using the installation assistant
+
+## Single-node offline installation
+
+Install and configure the single-node server on a 64-bit (**x86_64/AMD64** or **AARCH64/ARM64**) architecture with the aid of the Wazuh assisted installation method.
+
+### Prerequisites
+
+> **Note:** You need root user privileges to run all the commands described below. Please make sure that a copy of the `wazuh-install-files.tar` and `wazuh-offline.tar.gz` files, created during the initial configuration step, is placed in your working directory.
+
+#### Required dependencies
+
+The following dependencies must be installed on the Wazuh single node:
+
+**RPM-based systems:**
+
+- coreutils
+- libcap
+
+**DEB-based systems:**
+
+- coreutils
+- libcap
+
+#### Files needed
+
+For the single-node offline installation, you need to have the following files in your working directory:
+
+- `wazuh-install-files.tar`
+- `wazuh-offline.tar.gz`
+- `wazuh-install.sh`
+
+### Installation
+
+To perform the offline installation with the `--offline-installation` flag of Wazuh server on a single-node using the assisted method, run:
+
+```bash
+bash wazuh-install.sh --offline-installation -a
+```
+
+Once the assistant finishes the installation, the output shows the access credentials and a message that confirms that the installation was successful:
+
+```shell
+INFO: --- Summary ---
+INFO: You can access the web interface https://<wazuh_dashboard_ip>:443
+   User: admin
+   Password: admin
+
+INFO: Installation finished.
+```
+
+### Accessing the Wazuh Dashboard
+
+You now have installed and configured Wazuh.
+
+Access the Wazuh web interface with your admin user credentials. This is the default administrator account for the Wazuh indexer and it allows you to access the Wazuh dashboard.
+
+- **URL:** `https://<WAZUH_DASHBOARD_IP_ADDRESS>:443`
+- **Username:** `admin`
+- **Password:** `admin`
+
+---
+
+## Multi-node offline installation
+
+### Installing the Wazuh indexer
+
+Install and configure the Wazuh indexer nodes on a 64-bit (**x86_64/AMD64** or **AARCH64/ARM64**) architecture.
+
+#### Required dependencies
+
+The following dependencies must be installed on the Wazuh indexer nodes:
+
+**RPM-based systems:**
+
+- coreutils
+
+**DEB-based systems:**
+
+- coreutils
+
+#### Installation Steps
+
+1. Run the multi-node assisted method with the `--offline-installation` flag to perform an offline installation. Use the option `--wazuh-indexer` and the node name to install and configure the Wazuh indexer. The node name must be the same one used in `config.yml` for the initial configuration, for example, `indexer`.
+
+    ```bash
+    bash wazuh-install.sh --offline-installation --wazuh-indexer indexer
+    ```
+
+    Repeat this step for every Wazuh indexer node in your cluster. Then proceed with initializing your multi-node cluster in the next step.
+
+2. Run the Wazuh assisted installation option `--start-cluster` on any Wazuh indexer node to load the new certificates information and start the cluster.
+
+    ```bash
+    bash wazuh-install.sh --offline-installation --start-cluster
+    ```
+
+    > **Note:** You only have to initialize the cluster once. There is no need to run this command on every node.
+
+### Testing the cluster installation
+
+1. Run the following command to confirm that the installation is successful. Replace `<WAZUH_INDEXER_IP_ADDRESS>` with the configured Wazuh indexer IP address:
+
+    ```bash
+    curl -k -u admin:admin https://<WAZUH_INDEXER_IP_ADDRESS>:9200
+    ```
+
+    **Output example:**
+
+    ```json
+    {
+    "name" : "indexer",
+    "cluster_name" : "wazuh-cluster",
+    "cluster_uuid" : "095jEW-oRJSFKLz5wmo5PA",
+    "version" : {
+        "distribution" : "opensearch",
+        "number" : "3.5.0",
+        "build_type" : "deb",
+        "build_hash" : "0688bb0c0d4d2384772311ab88edcd2a18a67774",
+        "build_date" : "2026-04-09T01:00:23.398850475Z",
+        "build_snapshot" : false,
+        "lucene_version" : "10.3.2",
+        "minimum_wire_compatibility_version" : "2.19.0",
+        "minimum_index_compatibility_version" : "2.0.0"
+    },
+    "tagline" : "The OpenSearch Project: https://opensearch.org/"
+    }
+    ```
+
+2. Verify that the cluster is running correctly. Replace `<WAZUH_INDEXER_IP_ADDRESS>` in the following command, then execute it:
+
+    ```bash
+    curl -k -u admin:admin https://<WAZUH_INDEXER_IP_ADDRESS>:9200/_cat/nodes?v
+    ```
+
+### Installing the Wazuh manager
+
+#### Required dependencies
+
+**RPM-based systems (with yum package manager):**
+
+- libcap
+
+**DEB-based systems:**
+
+- libcap
+
+#### Installation Steps
+
+Run the assisted method with `--offline-installation` to perform an offline installation. Use the option `--wazuh-manager` followed by the node name to install the Wazuh manager. The node name must be the same one used in `config.yml` for the initial configuration, for example, `manager`.
+
+```bash
+bash wazuh-install.sh --offline-installation --wazuh-manager manager
+```
+
+Your Wazuh server is now successfully installed. Repeat this step on every Wazuh server node.
+
+### Installing the Wazuh dashboard
+
+#### Required dependencies
+
+The following dependencies must be installed on the Wazuh dashboard node:
+
+**RPM-based systems:**
+
+- libcap
+
+**DEB-based systems:**
+
+- libcap
+
+#### Installation Steps
+
+1. Run the assisted method with `--offline-installation` to perform an offline installation. Use the option `--wazuh-dashboard` and the node name to install and configure the Wazuh dashboard. The node name must be the same one used in `config.yml` for the initial configuration, for example, `dashboard`.
+
+    ```bash
+    bash wazuh-install.sh --offline-installation --wazuh-dashboard dashboard
+    ```
+
+The TCP port for the Wazuh web user interface (dashboard) is 443.
+
+#### Installation Summary
+
+Once the assistant finishes the installation, the output shows the access credentials and a message that confirms that the installation was successful:
+
+```shell
+INFO: --- Summary ---
+INFO: You can access the web interface https://<wazuh_dashboard_ip>:443
+   User: admin
+   Password: admin
+
+INFO: Installation finished.
+```
+
+### Accessing the Wazuh Dashboard
+
+You now have installed and configured Wazuh.
+
+Access the Wazuh web interface with your admin user credentials. This is the default administrator account for the Wazuh indexer and it allows you to access the Wazuh dashboard.
+
+- **URL:** `https://<WAZUH_DASHBOARD_IP_ADDRESS>`
+- **Username:** `admin`
+- **Password:** `admin`
+
+#### Certificate Notice
+
+When you access the Wazuh dashboard for the first time, the browser shows a warning message stating that the certificate was not issued by a trusted authority. An exception can be added in the advanced options of the web browser. For increased security, the `root-ca.pem` file previously generated can be imported to the certificate manager of the browser instead. Alternatively, a certificate from a trusted authority can be configured.

--- a/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md
+++ b/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md
@@ -1,6 +1,8 @@
 # Offline install step by step
 
-1. In the working directory where you placed `wazuh-offline.tar.gz` and `wazuh-install-files.tar`, execute the following command to decompress the installation files:
+## Decompress necessary installation files
+
+In the working directory where you placed `wazuh-offline.tar.gz` and `wazuh-install-files.tar`, execute the following command to decompress the installation files:
 
 ```bash
 tar xf wazuh-offline.tar.gz
@@ -120,7 +122,7 @@ The following dependencies must be installed on the Wazuh indexer nodes:
 
 ## Installing the Wazuh manager
 
-On systems with apt as package manager, the following dependencies must be installed on the Wazuh server nodes:
+On systems with apt as package manager, the following dependencies must be installed on the Wazuh manager nodes:
 
 - **gnupg**
 - **apt-transport-https**
@@ -200,9 +202,9 @@ On systems with apt as package manager, the following dependencies must be insta
 
 ### Wazuh cluster configuration for multi-node deployment
 
-After completing the installation of the Wazuh server on every node, configure one server node as master and the rest as workers.
+After completing the installation of the Wazuh manager on every node, configure one manager node as master and the rest as workers.
 
-#### Configuring the Wazuh server master node
+#### Configuring the Wazuh manager master node
 
 1. Edit the following settings in `/var/ossec/etc/ossec.conf`:
 
@@ -255,9 +257,9 @@ After completing the installation of the Wazuh server on every node, configure o
     /var/wazuh-manager/bin/cluster_control -l
     ```
 
-Repeat these configuration steps for every Wazuh server worker node in your cluster.
+Repeat these configuration steps for every Wazuh manager worker node in your cluster.
 
-#### Testing Wazuh server cluster
+#### Testing Wazuh manager cluster
 
 To verify that the Wazuh cluster is enabled and all the nodes are connected, run:
 

--- a/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md
+++ b/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md
@@ -1,0 +1,350 @@
+# Offline install step by step
+
+1. In the working directory where you placed `wazuh-offline.tar.gz` and `wazuh-install-files.tar`, execute the following command to decompress the installation files:
+
+```bash
+tar xf wazuh-offline.tar.gz
+tar xf wazuh-install-files.tar
+```
+
+## Installing the Wazuh indexer
+
+The following dependencies must be installed on the Wazuh indexer nodes:
+
+- **coreutils**
+
+1. Run the following commands to install the Wazuh indexer.
+
+    **RPM-based systems:**
+
+    ```bash
+    rpm -ivh ./wazuh-offline/wazuh-packages/wazuh-indexer*.rpm
+    ```
+
+    **DEB-based systems:**
+
+    ```bash
+    dpkg -i ./wazuh-offline/wazuh-packages/wazuh-indexer*.deb
+    ```
+
+2. Run the following commands replacing `<INDEXER_NODE_NAME>` with the name of the Wazuh indexer node you are configuring as defined in `config.yml`. For example, `indexer`. This deploys the SSL certificates to encrypt communications between the Wazuh central components.
+
+    ```bash
+    NODE_NAME=<INDEXER_NODE_NAME>
+    mkdir /etc/wazuh-indexer/certs
+    mv -n wazuh-install-files/$NODE_NAME.pem /etc/wazuh-indexer/certs/indexer.pem
+    mv -n wazuh-install-files/$NODE_NAME-key.pem /etc/wazuh-indexer/certs/indexer-key.pem
+    mv wazuh-install-files/admin-key.pem /etc/wazuh-indexer/certs/
+    mv wazuh-install-files/admin.pem /etc/wazuh-indexer/certs/
+    cp wazuh-install-files/root-ca.pem /etc/wazuh-indexer/certs/
+    chmod 500 /etc/wazuh-indexer/certs
+    chmod 400 /etc/wazuh-indexer/certs/*
+    chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/certs
+    ```
+
+    Here you move the node certificate and key files, such as `indexer.pem` and `indexer-key.pem`, to their corresponding certs folder. They are specific to each node and are not required on other nodes. The `root-ca.pem` certificate is copied so it can be reused in the next component configuration steps.
+
+3. Edit `/etc/wazuh-indexer/opensearch.yml` and replace the following values:
+
+   - `network.host`: Address of this node for HTTP and transport traffic. Use the same node address set in `config.yml`.
+   - `node.name`: Name of the Wazuh indexer node as defined in `config.yml` (for example, `indexer`).
+   - `cluster.initial_master_nodes`: List of master-eligible node names.
+
+        ```yaml
+        cluster.initial_master_nodes:
+            - "indexer"
+            - "indexer-2"
+            - "indexer-3"
+        ```
+
+   - `discovery.seed_hosts`: List of the addresses of the master-eligible nodes. For multi-node deployments, uncomment and set these values.
+
+        ```yaml
+        discovery.seed_hosts:
+            - "10.0.0.1"
+            - "10.0.0.2"
+            - "10.0.0.3"
+        ```
+
+   - `plugins.security.nodes_dn`: List of Distinguished Names of the certificates of all Wazuh indexer cluster nodes. Uncomment the lines for `indexer-2` and `indexer-3` and change the common names (CN) and values according to your settings and your `config.yml` definitions.
+
+        ```yaml
+        plugins.security.nodes_dn:
+        - "CN=indexer,OU=Wazuh,O=Wazuh,L=California,C=US"
+        - "CN=indexer-2,OU=Wazuh,O=Wazuh,L=California,C=US"
+        - "CN=indexer-3,OU=Wazuh,O=Wazuh,L=California,C=US"
+        ```
+
+4. Enable and start the Wazuh indexer service.
+
+    ```bash
+    systemctl daemon-reload
+    systemctl enable wazuh-indexer
+    systemctl start wazuh-indexer
+    ```
+
+5. For multi-node clusters, repeat the previous steps on every Wazuh indexer node.
+
+6. When all Wazuh indexer nodes are running, run the Wazuh indexer `indexer-security-init.sh` script on any Wazuh indexer node to load the new certificates information and start the cluster.
+
+    ```bash
+    /usr/share/wazuh-indexer/bin/indexer-security-init.sh
+    ```
+
+7. Run the following command to check that the installation is successful. This command uses `127.0.0.1`; set your Wazuh indexer address if necessary.
+
+    ```bash
+    curl -XGET https://127.0.0.1:9200 -u admin:admin -k
+    ```
+
+    Example output:
+
+    ```json
+    {
+        "name": "indexer",
+        "cluster_name": "wazuh-cluster",
+        "cluster_uuid": "095jEW-oRJSFKLz5wmo5PA",
+        "version": {
+            "number": "7.10.2",
+            "build_type": "rpm",
+            "build_hash": "db90a415ff2fd428b4f7b3f800a51dc229287cb4",
+            "build_date": "2023-06-03T06:24:25.112415503Z",
+            "build_snapshot": false,
+            "lucene_version": "9.6.0",
+            "minimum_wire_compatibility_version": "7.10.0",
+            "minimum_index_compatibility_version": "7.0.0"
+        },
+        "tagline": "The OpenSearch Project: https://opensearch.org/"
+    }
+    ```
+
+## Installing the Wazuh manager
+
+On systems with apt as package manager, the following dependencies must be installed on the Wazuh server nodes:
+
+- **gnupg**
+- **apt-transport-https**
+
+1. Run the following commands to import the Wazuh key and install the Wazuh manager.
+
+    **RPM-based systems:**
+
+    ```bash
+    rpm -ivh ./wazuh-offline/wazuh-packages/wazuh-manager*.rpm
+    ```
+
+    **DEB-based systems:**
+
+    ```bash
+    dpkg -i ./wazuh-offline/wazuh-packages/wazuh-manager*.deb
+    ```
+
+2. Deploy the SSL certificates for secure communication between the Wazuh manager and indexer. These certificates should be extracted from the `wazuh-certificates/` directory generated during the certificate creation process.
+
+    ```BASH
+    NODE_NAME=<MANAGER_NODE_NAME>
+    ```
+
+    ```BASH
+    mkdir -p /var/ossec/etc/certs
+    cp ./wazuh-certificates/root-ca.pem /var/wazuh-manager/etc/certs/root-ca.pem
+    mv ./wazuh-certificates/$NODE_NAME.pem /var/wazuh-manager/etc/certs/manager.pem
+    mv ./wazuh-certificates/$NODE_NAME-key.pem /var/wazuh-manager/etc/certs/manager-key.pem
+    chmod 500 /var/wazuh-manager/etc/certs
+    chmod 400 /var/wazuh-manager/etc/certs/*
+    chown -R wazuh-manager:wazuh-manager /var/wazuh-manager/etc/certs
+    ```
+
+    > [!NOTE]
+    > Replace `<MANAGER_NODE_NAME>` with the name you used when generating the certificates.
+
+3. Save the Wazuh indexer username and password into the Wazuh manager keystore using the `wazuh-keystore` tool:
+
+    ```bash
+    echo '<INDEXER_USERNAME>' | /var/ossec/bin/wazuh-keystore -f indexer -k username
+    echo '<INDEXER_PASSWORD>' | /var/ossec/bin/wazuh-keystore -f indexer -k password
+    ```
+
+    > Note: The default offline-installation credentials are `admin:admin`.
+
+    Update the indexer configuration in `/var/wazuh-manager/etc/wazuh-manager.conf` to specify the indexer IP address:
+
+    ```xml
+    <indexer>
+    <hosts>
+        <host>https://127.0.0.1:9200</host>
+    </hosts>
+    <ssl>
+        <certificate_authorities>
+        <ca>/var/wazuh-manager/etc/certs/root-ca.pem</ca>
+        </certificate_authorities>
+        <certificate>/var/wazuh-manager/etc/certs/manager.pem</certificate>
+        <key>/var/wazuh-manager/etc/certs/manager-key.pem</key>
+    </ssl>
+    </indexer>
+    ```
+
+4. Enable and start the Wazuh manager service.
+
+    ```bash
+    systemctl daemon-reload
+    systemctl enable wazuh-manager
+    systemctl start wazuh-manager
+    ```
+
+5. Run the following command to verify that the Wazuh manager status is active.
+
+    ```bash
+    systemctl status wazuh-manager
+    ```
+
+### Wazuh cluster configuration for multi-node deployment
+
+After completing the installation of the Wazuh server on every node, configure one server node as master and the rest as workers.
+
+#### Configuring the Wazuh server master node
+
+1. Edit the following settings in `/var/ossec/etc/ossec.conf`:
+
+    ```xml
+    <cluster>
+        <name>wazuh</name>
+        <node_name>master-node</node_name>
+        <node_type>master</node_type>
+        <key>c98b62a9b6169ac5f67dae55ae4a9088</key>
+        <port>1516</port>
+        <bind_addr>0.0.0.0</bind_addr>
+        <nodes>
+            <node><WAZUH_MASTER_ADDRESS></node>
+        </nodes>
+        <hidden>no</hidden>
+        <disabled>no</disabled>
+    </cluster>
+    ```
+
+    Replace `MASTER_NODE_IP` with the actual IP address of the master node.
+
+2. On each worker node, edit `/var/wazuh-manager/etc/wazuh-manager.conf`
+
+    ```xml
+    <cluster>
+    <name>wazuh</name>
+    <node_name>worker-node-01</node_name>
+    <node_type>worker</node_type>
+    <key>fd3350b86d239654e34866ab3c4988a8</key>
+    <port>1516</port>
+    <bind_addr>0.0.0.0</bind_addr>
+    <nodes>
+        <node>MASTER_NODE_IP</node>
+    </nodes>
+    <hidden>no</hidden>
+    </cluster>
+    ```
+
+    Replace `MASTER_NODE_IP` with the actual IP address of the master node, and use a unique `node_name` for each worker.
+
+3. Restart the Wazuh manager service on all nodes after making configuration changes:
+
+    ```BASH
+    systemctl restart wazuh-manager
+    ```
+
+4. Verify the cluster status from any node:
+
+    ```BASH
+    /var/wazuh-manager/bin/cluster_control -l
+    ```
+
+Repeat these configuration steps for every Wazuh server worker node in your cluster.
+
+#### Testing Wazuh server cluster
+
+To verify that the Wazuh cluster is enabled and all the nodes are connected, run:
+
+```bash
+/var/wazuh-manager/bin/cluster_control -l
+```
+
+Example output:
+
+```text
+NAME     TYPE    VERSION  ADDRESS
+manager  master  4.12.0   10.0.0.3
+manager-2  worker  4.12.0   10.0.0.5
+manager-3  worker  4.12.0   10.0.0.4
+```
+
+## Installing the Wazuh dashboard
+
+The following dependencies must be installed on the Wazuh dashboard node:
+
+- **libcap**
+
+1. Run the following commands to install the Wazuh dashboard.
+
+    **RPM-based systems:**
+
+    ```bash
+    rpm -ivh ./wazuh-offline/wazuh-packages/wazuh-dashboard*.rpm
+    ```
+
+    **DEB-based systems:**
+
+    ```bash
+    dpkg -i ./wazuh-offline/wazuh-packages/wazuh-dashboard*.deb
+    ```
+
+2. Edit `/etc/wazuh-dashboard/opensearch_dashboards.yml` and replace the following values:
+
+   - `server.host`: This setting specifies the host of the Wazuh dashboard server. To allow remote users to connect, set the value to the IP address or DNS name of the Wazuh dashboard server. The value 0.0.0.0 will accept all the available IP addresses of the host.
+   - `opensearch.hosts`: The URLs of the Wazuh indexer instances to use for all your queries. The Wazuh dashboard can be configured to connect to multiple Wazuh indexer nodes in the same cluster. The addresses of the nodes can be separated by commas. For example, ["https://10.0.0.2:9200", "https://10.0.0.3:9200","https://10.0.0.4:9200"]
+   - `wazuh_core.hosts`: The Wazuh manager hosts that the dashboard will use to query the Wazuh manager API. At least one host is required. Each host entry defined with an unique ID and must include:
+   - `url`: The URL to the server API including the protocol and address (DNS or IP).
+   - `port`: The port where is served.
+   - `username`: The user that runs the requests.
+   - `password`: The password for the user.
+   - `run_as`: This defines how the dashboard requests the data, using the default configured account (false) or the current user's context (true).
+
+    ```yaml
+    server.host: 0.0.0.0
+    server.port: 443
+    opensearch.hosts: https://127.0.0.1:9200
+    opensearch.ssl.verificationMode: certificate
+    ---
+    wazuh_core.hosts:
+    default:
+        url: https://127.0.0.1
+        port: 55000
+        username: wazuh-wui
+        password: wazuh-wui
+        run_as: false
+    ```
+
+3. Replace `<DASHBOARD_NODE_NAME>` with your Wazuh dashboard node name used in `config.yml` (for example, `dashboard`) and move the certificates.
+
+    ```bash
+    NODE_NAME=<DASHBOARD_NODE_NAME>
+    mkdir /etc/wazuh-dashboard/certs
+    mv -n wazuh-install-files/$NODE_NAME.pem /etc/wazuh-dashboard/certs/dashboard.pem
+    mv -n wazuh-install-files/$NODE_NAME-key.pem /etc/wazuh-dashboard/certs/dashboard-key.pem
+    cp wazuh-install-files/root-ca.pem /etc/wazuh-dashboard/certs/
+    chmod 500 /etc/wazuh-dashboard/certs
+    chmod 400 /etc/wazuh-dashboard/certs/*
+    chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/certs
+    ```
+
+4. Enable and start the Wazuh dashboard.
+
+    ```bash
+    systemctl daemon-reload
+    systemctl enable wazuh-dashboard
+    systemctl start wazuh-dashboard
+    ```
+
+5. Access the Wazuh web interface.
+
+- URL: `https://<WAZUH_DASHBOARD_IP_ADDRESS>:443`
+- Username: `admin`
+- Password: `admin`
+
+Upon first access, the browser may show a certificate warning. You can add an exception in the browser advanced options, import `root-ca.pem` into the browser certificate manager, or configure a certificate signed by a trusted authority.

--- a/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md
+++ b/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md
@@ -345,8 +345,8 @@ The following dependencies must be installed on the Wazuh dashboard node:
 
 5. Access the Wazuh web interface.
 
-- URL: `https://<WAZUH_DASHBOARD_IP_ADDRESS>:443`
-- Username: `admin`
-- Password: `admin`
+   - URL: `https://<WAZUH_DASHBOARD_IP_ADDRESS>:443`
+   - Username: `admin`
+   - Password: `admin`
 
 Upon first access, the browser may show a certificate warning. You can add an exception in the browser advanced options, import `root-ca.pem` into the browser certificate manager, or configure a certificate signed by a trusted authority.


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-installation-assistant/issues/662

# Description

The aim of this PR is to include the Offline Installation documentation.

The documentation has been added under the `docs/guide/` and there are three folders:
- `offline-download-packages`
- `offline-installation-assistant-deployments`
- `offline-step-by-step-deployments`

## Documentation files

### `offline-download-packages.md`

This file contains the documentation related to the previous step of downloading the packages needed selected by architechture and package manager and certificates creation.

### `offline-assisted-install.md`

This file contains the guide to install Wazuh Offline in single-node and multi-node versions using the Installation Assistant script.

### `offline-step-by-step.md`

This file contains the guide to install Wazuh Offline in single-node and multi-node versions installing and configuring the Wazuh central components step by step.