### PR TITLE
Prevent curl errors and cascading uninstalls when running with -d flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Prevent curl errors and cascading uninstalls when running with -d flag ([#712](https://github.com/wazuh/wazuh-installation-assistant/pull/712))
 
 ### Deleted
 

--- a/install_functions/checks.sh
+++ b/install_functions/checks.sh
@@ -487,54 +487,41 @@ function checks_available_port() {
 }
 
 function checks_filebeatURL() {
-    # URL uses branch when the source_branch is not a stage branch
-    if [[ ! $last_stage ]]; then
-        source_branch="${source_branch#v}"
-        filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
-    fi
-
-    # URL using master branch
-    new_filebeat_url="${filebeat_wazuh_template/${source_branch}/${wazuh_version}}"
-
-    response=$(curl -I --write-out '%{http_code}' --silent --output /dev/null $filebeat_wazuh_template)
-    if [ "${response}" != "200" ]; then
-        response=$(curl -I --write-out '%{http_code}' --silent --output /dev/null $new_filebeat_url)
-
-        # Display error if both URLs do not get the resource
-        if [ "${response}" != "200" ]; then
-            common_logger -e "Could not get the Filebeat Wazuh template."
-        else
-            common_logger "Using Filebeat template from ${wazuh_version} branch."
-            filebeat_wazuh_template="${new_filebeat_url}"
+    # if the filebeat template URL is defined and accessible, return it, no need to check other URLs
+    if [ -n "${filebeat_wazuh_template}" ]; then
+        response=$(curl -I --write-out '%{http_code}' --silent --output /dev/null $filebeat_wazuh_template)
+        if [ "${response}" == "200" ]; then
+            common_logger -d "Using Filebeat template from ${source_branch} branch."
+            return
         fi
+        common_logger -d "The provided Filebeat template URL (${filebeat_wazuh_template}) is not accessible. Trying with other URLs."
     fi
-}
 
-function checks_development_source_tag() {
-    source_branch="${source_branch}-${last_stage}"
-
-    # Check if the stage tag exists
-    status_code=$(curl -s -o /dev/null -w "%{http_code}" \
-        "https://api.github.com/repos/wazuh/wazuh-installation-assistant/git/refs/tags/$source_branch")
-
-    if [ "$status_code" -ne 200 ]; then
-        common_logger -w "Tag '$source_branch' does not exist. Using the source branch related to the Wazuh version ($wazuh_version)."
-        source_branch="${wazuh_version}"
-
-        # Check if the source branch exists
-        checks_source_branch
+    # If the URL with the tag exists and is accessible, use it
+    if [ -n "${last_stage}" ]; then
+        tag_branch="${source_branch}-${last_stage}"
+        filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${tag_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
+        response=$(curl -I --write-out '%{http_code}' --silent --output /dev/null $filebeat_wazuh_template)
+        if [ "${response}" == "200" ]; then
+            source_branch="${tag_branch}"
+            common_logger -d "Using Filebeat template from ${source_branch} tag."
+            return
+        fi
+        common_logger -d "The Filebeat template URL with the tag ${tag_branch} (${filebeat_wazuh_template}) is not accessible. Trying with base branch."
     fi
-}
 
-function checks_source_branch() {
-    # Check if the source branch exists
-    status_code=$(curl -s -o /dev/null -w "%{http_code}" \
-        "https://api.github.com/repos/wazuh/wazuh-installation-assistant/branches/$source_branch")
-
-    if [ "$status_code" -ne 200 ]; then
-        common_logger -w "Branch '$source_branch' does not exist. Using the ${wazuh_version} branch."
-        source_branch="${wazuh_version}"
+    # if the URL with the tag does not exist or is not accessible, try with the branch
+    source_branch="${source_branch#v}"
+    filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
+    response=$(curl -I --write-out '%{http_code}' --silent --output /dev/null $filebeat_wazuh_template)
+    if [ "${response}" == "200" ]; then
+        common_logger -d "Using Filebeat template from ${source_branch} branch."
+        return
     fi
+
+    common_logger -e "Could not get the Filebeat Wazuh template from Wazuh repository."
+    installCommon_rollBack
+    exit 1
 }
 
 function checks_firewall(){

--- a/install_functions/installCommon.sh
+++ b/install_functions/installCommon.sh
@@ -918,7 +918,7 @@ function installCommon_aptRemoveWIADependencies(){
                 mapfile -t wazuh_deps < <(printf '%s\n' "${wazuh_deps[@]}" | sort -u)
             fi
         fi
-        common_logger -d "Wazuh components dependencies: ${wazuh_deps[*]}"
+
         for dep in "${wia_dependencies_installed[@]}"; do
             if [ "${dep}" != "systemd" ]; then
                 if [[ " ${wazuh_deps[*]} " == *" ${dep} "* ]]; then

--- a/install_functions/installCommon.sh
+++ b/install_functions/installCommon.sh
@@ -854,8 +854,13 @@ function installCommon_yumRemoveWIADependencies(){
 
     if [ "${#wia_dependencies_installed[@]}" -gt 0 ]; then
         common_logger "--- Dependencies ---"
+        local wazuh_deps=( $(echo "${wazuh_yum_dependencies[@]}" "${indexer_yum_dependencies[@]}" "${dashboard_yum_dependencies[@]}" | tr ' ' '\n' | sort -u) )
         for dep in "${wia_dependencies_installed[@]}"; do
             if [ "${dep}" != "systemd" ]; then
+                if [[ " ${wazuh_deps[*]} " == *" ${dep} "* ]]; then
+                    common_logger -d "Skipping removal of ${dep}: it is also a Wazuh component dependency."
+                    continue
+                fi
                 common_logger "Removing $dep."
                 yum_output=$(yum remove ${dep} -y 2>&1)
                 yum_code="${PIPESTATUS[0]}"
@@ -875,8 +880,14 @@ function installCommon_aptRemoveWIADependencies(){
 
     if [ "${#wia_dependencies_installed[@]}" -gt 0 ]; then
         common_logger "--- Dependencies ----"
+        local wazuh_deps=( $(echo "${wazuh_apt_dependencies[@]}" "${indexer_apt_dependencies[@]}" "${dashboard_apt_dependencies[@]}" | tr ' ' '\n' | sort -u) )
+        common_logger -d "Wazuh components dependencies: ${wazuh_deps[*]}"
         for dep in "${wia_dependencies_installed[@]}"; do
             if [ "${dep}" != "systemd" ]; then
+                if [[ " ${wazuh_deps[*]} " == *" ${dep} "* ]]; then
+                    common_logger -d "Skipping removal of ${dep}: it is also a Wazuh component dependency."
+                    continue
+                fi
                 common_logger "Removing $dep."
                 apt_output=$(apt-get remove --purge ${dep} -y 2>&1)
                 apt_code="${PIPESTATUS[0]}"

--- a/install_functions/installCommon.sh
+++ b/install_functions/installCommon.sh
@@ -854,7 +854,26 @@ function installCommon_yumRemoveWIADependencies(){
 
     if [ "${#wia_dependencies_installed[@]}" -gt 0 ]; then
         common_logger "--- Dependencies ---"
-        local wazuh_deps=( $(echo "${wazuh_yum_dependencies[@]}" "${indexer_yum_dependencies[@]}" "${dashboard_yum_dependencies[@]}" | tr ' ' '\n' | sort -u) )
+        local wazuh_deps=()
+
+        if [ -n "${AIO}" ]; then
+            wazuh_deps=( $(echo "${wazuh_yum_dependencies[@]}" "${indexer_yum_dependencies[@]}" "${dashboard_yum_dependencies[@]}" | tr ' ' '\n' | sort -u) )
+        else
+            if [ -n "${wazuh}" ]; then
+                wazuh_deps+=( "${wazuh_yum_dependencies[@]}" )
+            fi
+            if [ -n "${indexer}" ]; then
+                wazuh_deps+=( "${indexer_yum_dependencies[@]}" )
+            fi
+            if [ -n "${dashboard}" ]; then
+                wazuh_deps+=( "${dashboard_yum_dependencies[@]}" )
+            fi
+
+            if [ "${#wazuh_deps[@]}" -gt 0 ]; then
+                mapfile -t wazuh_deps < <(printf '%s\n' "${wazuh_deps[@]}" | sort -u)
+            fi
+        fi
+
         for dep in "${wia_dependencies_installed[@]}"; do
             if [ "${dep}" != "systemd" ]; then
                 if [[ " ${wazuh_deps[*]} " == *" ${dep} "* ]]; then
@@ -880,7 +899,25 @@ function installCommon_aptRemoveWIADependencies(){
 
     if [ "${#wia_dependencies_installed[@]}" -gt 0 ]; then
         common_logger "--- Dependencies ----"
-        local wazuh_deps=( $(echo "${wazuh_apt_dependencies[@]}" "${indexer_apt_dependencies[@]}" "${dashboard_apt_dependencies[@]}" | tr ' ' '\n' | sort -u) )
+        local wazuh_deps=()
+
+        if [ -n "${AIO}" ]; then
+            wazuh_deps=( $(echo "${wazuh_apt_dependencies[@]}" "${indexer_apt_dependencies[@]}" "${dashboard_apt_dependencies[@]}" | tr ' ' '\n' | sort -u) )
+        else
+            if [ -n "${wazuh}" ]; then
+                wazuh_deps+=( "${wazuh_apt_dependencies[@]}" )
+            fi
+            if [ -n "${indexer}" ]; then
+                wazuh_deps+=( "${indexer_apt_dependencies[@]}" )
+            fi
+            if [ -n "${dashboard}" ]; then
+                wazuh_deps+=( "${dashboard_apt_dependencies[@]}" )
+            fi
+
+            if [ "${#wazuh_deps[@]}" -gt 0 ]; then
+                mapfile -t wazuh_deps < <(printf '%s\n' "${wazuh_deps[@]}" | sort -u)
+            fi
+        fi
         common_logger -d "Wazuh components dependencies: ${wazuh_deps[*]}"
         for dep in "${wia_dependencies_installed[@]}"; do
             if [ "${dep}" != "systemd" ]; then

--- a/install_functions/installMain.sh
+++ b/install_functions/installMain.sh
@@ -119,14 +119,6 @@ function main() {
                     devrepo="pre-release"
                     shift 1
                 fi
-                checks_development_source_tag
-                repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"
-                repobaseurl="https://packages-dev.wazuh.com/${devrepo}"
-                reporelease="unstable"
-                filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
-                filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.5.tar.gz"
-                bucket="packages-dev.wazuh.com"
-                repository="${devrepo}"
                 ;;
 
             "-fd"|"--force-install-dashboard")
@@ -279,6 +271,11 @@ function main() {
     checks_arguments
     if [ -n "${development}" ]; then
         checks_filebeatURL
+        repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"
+        repobaseurl="https://packages-dev.wazuh.com/${devrepo}"
+        reporelease="unstable"
+        filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.5.tar.gz"
+        bucket="packages-dev.wazuh.com"
     fi
     if [ -n "${uninstall}" ]; then
         installCommon_rollBack

--- a/install_functions/installMain.sh
+++ b/install_functions/installMain.sh
@@ -256,7 +256,9 @@ function main() {
 # -------------- Uninstall case  ------------------------------------
 
     common_checkSystem
-
+    common_checkInstalled
+    checks_arguments
+    
     if [ -z "${download}" ]; then
         check_dist
     fi
@@ -267,8 +269,6 @@ function main() {
         offline_checkPrerequisites "wia_offline_dependencies" "${wia_offline_dependencies[@]}"
     fi
 
-    common_checkInstalled
-    checks_arguments
     if [ -n "${development}" ]; then
         checks_filebeatURL
         repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"


### PR DESCRIPTION
## Problem

When running the installation assistant with the `-d` flag (development mode) on a system without `curl` pre-installed, the following errors appeared before the tool had a chance to install `curl` via its dependency check:

```
./wazuh-install.sh: line 1275: curl: command not found
./wazuh-install.sh: line 1277: [: : integer expression expected
```

Root cause: The `-d` argument parsing block called `checks_development_source_tag` function immediately, which internally used `curl` to check whether a pre-release tag existed in the GitHub API. This happened before `installCommon_installCheckDependencies` had run to install `curl`.

## Solution

### `install_functions/checks.sh`

- Removed `checks_development_source_tag` and `checks_source_branch` functions.
- Refactored `checks_filebeatURL` to consolidate all URL resolution logic in a single, sequential fallback chain:
  1. If `filebeat_wazuh_template` is already set and accessible (HTTP 200), use it and return.
  2. If `last_stage` is set (pre-release build), try the tag URL (e.g., `v4.14.5-rc1`). If accessible, update `source_branch` and return.
  3. Fall back to the version branch URL (stripping the `v` prefix from `source_branch`). If accessible, return.
  4. If none of the URLs are accessible, log an error, roll back, and exit.

With this we manage to use a single function to resolve the `source_branch` and validate the template URL, instead of splitting it into 3 different functions that did practically the same thing.

### `install_functions/installMain.sh`

- Removed the `checks_development_source_tag` call from the `-d` argument parsing block, which runs before curl is installed.
- Moved the development repository variable assignments (`repogpg`, `repobaseurl`, `reporelease`, `filebeat_wazuh_module`, `bucket`) to after `installCommon_installCheckDependencies` runs, alongside `checks_filebeatURL`, where `curl` is guaranteed to be available.


With this we let the `-d` argument block only set `development` and `devrepo`, and we leave all the logic for validating URLs and assigning variables related to the development repository for later, when the necessary dependencies to perform those validations (like curl) have already been installed.

## Other improvements

### Moved `checks_arguments` before `installCommon_installCheckDependencies`

Previously, the execution order in `main` was:

1. `installCommon_installCheckDependencies` — installs WIA dependencies (e.g. `curl`, `gawk`).
2. `checks_arguments` — validates argument combinations and, if `-o|--overwrite` was specified, calls `installCommon_rollBack`.

`installCommon_rollBack` removes the WIA dependencies that were just installed. This meant that after the rollback, tools like `curl` were no longer available even though the script still needed them (e.g. for `checks_filebeatURL`).

<details><summary>Example with bug</summary>

```
admin@ip-172-31-43-62:~$ sudo bash ./wazuh-install.sh -a --ignore-check -d pre-release -o
21/04/2026 15:10:45 INFO: Starting Wazuh installation assistant. Wazuh version: 4.14.5
21/04/2026 15:10:45 INFO: Verbose logging redirected to /var/log/wazuh-install.log
21/04/2026 15:10:45 INFO: The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Amazon Linux 2023; Ubuntu 16.04, 18.04, 20.04, 22.04; Rocky Linux 9.4.
21/04/2026 15:10:45 WARNING: The current system does not match with the list of recommended systems. The installation may not work properly.
21/04/2026 15:10:48 INFO: --- Dependencies ----
21/04/2026 15:10:48 INFO: Installing curl.
21/04/2026 15:10:50 INFO: --- Removing existing Wazuh installation ---
21/04/2026 15:10:50 INFO: Removing Wazuh manager.
21/04/2026 15:10:56 INFO: Wazuh manager removed.
21/04/2026 15:10:56 INFO: Removing Wazuh indexer.
21/04/2026 15:10:58 INFO: Wazuh indexer removed.
21/04/2026 15:10:58 INFO: Removing Filebeat.
21/04/2026 15:10:59 INFO: Filebeat removed.
21/04/2026 15:10:59 INFO: --- Dependencies ----
21/04/2026 15:10:59 INFO: Removing curl.
21/04/2026 15:11:00 INFO: Installation cleaned.
./wazuh-install.sh: line 1920: curl: command not found
./wazuh-install.sh: line 1932: curl: command not found
./wazuh-install.sh: line 1944: curl: command not found
21/04/2026 15:11:00 ERROR: Could not get the Filebeat Wazuh template from the Wazuh repository.
```

</details>

<details><summary>Example solving the bug</summary>

```
admin@ip-172-31-43-62:~$ sudo bash ./wazuh-install.sh -a --ignore-check -d pre-release -o
21/04/2026 15:44:57 INFO: Starting Wazuh installation assistant. Wazuh version: 4.14.5
21/04/2026 15:44:57 INFO: Verbose logging redirected to /var/log/wazuh-install.log
21/04/2026 15:45:03 INFO: --- Removing existing Wazuh installation ---
21/04/2026 15:45:03 INFO: Removing Wazuh manager.
21/04/2026 15:45:12 INFO: Wazuh manager removed.
21/04/2026 15:45:12 INFO: Removing Wazuh indexer.
21/04/2026 15:45:14 INFO: Wazuh indexer removed.
21/04/2026 15:45:14 INFO: Removing Filebeat.
21/04/2026 15:45:15 INFO: Filebeat removed.
21/04/2026 15:45:15 INFO: Installation cleaned.
21/04/2026 15:45:15 INFO: The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Amazon Linux 2023; Ubuntu 16.04, 18.04, 20.04, 22.04; Rocky Linux 9.4.
21/04/2026 15:45:15 WARNING: The current system does not match with the list of recommended systems. The installation may not work properly.
21/04/2026 15:45:18 INFO: --- Dependencies ----
21/04/2026 15:45:18 INFO: Installing curl.
```

</details>

The fix moves `checks_arguments` before `installCommon_installCheckDependencies`, so that any required rollback happens before dependencies are installed. Dependencies are then installed unconditionally afterwards, and are guaranteed to be present for the rest of the script.

### Fixed WIA dependency removal removing Wazuh packages (`installCommon.sh`)

When `installCommon_removeWIADependencies` ran at the end of an installation step, it removed packages that were installed as WIA dependencies (e.g. `curl`) even when those same packages are also declared as Wazuh component dependencies (e.g. `dashboard_apt_dependencies` includes `curl`). On Debian/Ubuntu, `apt-get remove --purge curl` would cascade and uninstall `wazuh-dashboard` along with it.

The fix builds a deduplicated union of all Wazuh component dependency arrays (`wazuh_*_dependencies`, `indexer_*_dependencies`, `dashboard_*_dependencies`) and skips removal of any WIA dependency that appears in that list, since those packages are owned by the Wazuh components themselves.

<details><summary>Remove in cascade example</summary>

```
21/04/2026 14:37:14 INFO: --- Summary ---
21/04/2026 14:37:14 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: xxxxxxx
21/04/2026 14:37:14 INFO: --- Dependencies ----
21/04/2026 14:37:14 INFO: Removing curl.
Reading package lists... Building dependency tree... Reading state information... The following package was automatically installed and is no longer required: libcurl4 Use 'sudo apt autoremove' to remove it. The following packages will be REMOVED: curl* wazuh-dashboard* 0 upgraded, 0 newly installed, 2 to remove and 28 not upgraded. After this operation, OKrging configuration files for wazuh-dashboard (4.14.5-1) ...talled.))
```

</details>

<details><summary>Example with WIA dependency removal fix</summary>

```
...
22/04/2026 10:02:47 INFO: --- Dependencies ----
22/04/2026 10:02:47 INFO: Removing gawk.
Reading package lists... Building dependency tree... Reading state information... The following package was automatically installed and is no longer required: libsigsegv2 Use 'sudo apt autoremove' to remove it. The following packages will be REMOVED: gawk* 0 upgraded, 0 newly installed, 1 to remove and 28 not upgraded. After this operation, 2976 kB disk  Purging configuration files for gawk (1:5.2.1-2) ...rrently installed.)in auto mode
22/04/2026 10:03:00 DEBUG: Skipping removal of curl: it is also a Wazuh component dependency.
22/04/2026 10:03:00 INFO: Removing lsof.
Reading package lists... Building dependency tree... Reading state information... The following package was automatically installed and is no longer required: libsigsegv2 Use 'sudo apt autoremove' to remove it. The following packages will be REMOVED: lsof* 0 upgraded, 0 newly installed, 1 to remove and 28 not upgraded. After this operation, 494 kB disk s Processing triggers for man-db (2.11.2-2) ...ries currently installed.)
22/04/2026 10:03:05 DEBUG: Restoring Wazuh repository.
22/04/2026 10:03:05 INFO: Installation finished.
...
```

If we are installing a component instead of an AIO, and a WIA dependency does not belong to that component, it will also be removed. For example with curl that does not belong to the indexer. If we only install the indexer, curl will be removed since it is not a dependency of the indexer, only of the dashboard.

```
sudo bash wazuh-install.sh -wi wazuh-indexer --ignore-check -d pre-release -v
...
22/04/2026 10:20:39 INFO: --- Dependencies ----
22/04/2026 10:20:39 INFO: Removing curl.
Reading package lists... Building dependency tree... Reading state information... The following package was automatically installed and is no longer required: libcurl4 Use 'sudo apt autoremove' to remove it. The following packages will be REMOVED: curl* 0 upgraded, 0 newly installed, 1 to remove and 28 not upgraded. After this operation, 501 kB disk spac Processing triggers for man-db (2.11.2-2) ...ies currently installed.)
22/04/2026 10:20:40 INFO: Removing lsof.
Reading package lists... Building dependency tree... Reading state information... The following package was automatically installed and is no longer required: libcurl4 Use 'sudo apt autoremove' to remove it. The following packages will be REMOVED: lsof* 0 upgraded, 0 newly installed, 1 to remove and 28 not upgraded. After this operation, 494 kB disk spac Processing triggers for man-db (2.11.2-2) ...ies currently installed.)
22/04/2026 10:20:41 DEBUG: Restoring Wazuh repository.
22/04/2026 10:20:41 INFO: Installation finished.
...
```

</details>

## Testing 🧪 

#### Testing filebeat template URL resolution logic

<details><summary>Tagged branch which does not exists (v4.14.5-beta1)</summary>

```
...
21/04/2026 14:25:48 DEBUG: Checking Wazuh installation.
21/04/2026 14:25:49 DEBUG: The provided Filebeat template URL (https://raw.githubusercontent.com/wazuh/wazuh/v4.14.5/extensions/elasticsearch/7.x/wazuh-template.json) is not accessible. Trying with other URLs.
21/04/2026 14:25:49 DEBUG: The Filebeat template URL with the tag v4.14.5-beta1 (https://raw.githubusercontent.com/wazuh/wazuh/v4.14.5-beta1/extensions/elasticsearch/7.x/wazuh-template.json) is not accessible. Trying with base branch.
21/04/2026 14:25:49 DEBUG: Using Filebeat template from 4.14.5 branch.
...
```

</details>

<details><summary>Tagged branch which exists (v4.14.5-rc1)</summary>

```
...
21/04/2026 14:27:41 DEBUG: Checking Wazuh installation.
21/04/2026 14:27:42 DEBUG: The provided Filebeat template URL (https://raw.githubusercontent.com/wazuh/wazuh/v4.14.5/extensions/elasticsearch/7.x/wazuh-template.json) is not accessible. Trying with other URLs.
21/04/2026 14:27:42 DEBUG: Using Filebeat template from v4.14.5-rc1 tag.
...
```

</details>

<details><summary>Branch which does not exists (4.14.8)</summary>

```
...
21/04/2026 14:26:53 DEBUG: Checking Wazuh installation.
21/04/2026 14:26:53 DEBUG: The provided Filebeat template URL (https://raw.githubusercontent.com/wazuh/wazuh/v4.14.8/extensions/elasticsearch/7.x/wazuh-template.json) is not accessible. Trying with other URLs.
21/04/2026 14:26:53 DEBUG: The Filebeat template URL with the tag v4.14.8-beta1 (https://raw.githubusercontent.com/wazuh/wazuh/v4.14.8-beta1/extensions/elasticsearch/7.x/wazuh-template.json) is not accessible. Trying with base branch.
21/04/2026 14:26:54 ERROR: Could not get the Filebeat Wazuh template from the Wazuh repository.
21/04/2026 14:26:54 INFO: --- Removing existing Wazuh installation ---
21/04/2026 14:26:54 DEBUG: Removing GPG key from system.
21/04/2026 14:26:54 INFO: Wazuh GPG key not found in the system
21/04/2026 14:26:54 INFO: Installation cleaned. Check the /var/log/wazuh-install.log file to learn more about the issue.
```

</details>

#### Reproduce by running on a clean Debian 12 system without `curl` installed

<details><summary>Installation logs</summary>

```bash
admin@ip-172-31-42-31:~$ curl -V
bash: curl: command not found

admin@ip-172-31-42-31:~$ sudo bash wazuh-install.sh -a --ignore-check -d pre-release -v
22/04/2026 09:56:35 DEBUG: Checking root permissions.
22/04/2026 09:56:35 INFO: Starting Wazuh installation assistant. Wazuh version: 4.14.5
22/04/2026 09:56:35 INFO: Verbose logging redirected to /var/log/wazuh-install.log
22/04/2026 09:56:35 DEBUG: APT package manager will be used.
22/04/2026 09:56:35 DEBUG: Checking Wazuh installation.
22/04/2026 09:56:36 DEBUG: Checking system distribution.
22/04/2026 09:56:36 INFO: The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Amazon Linux 2023; Ubuntu 16.04, 18.04, 20.04, 22.04; Rocky Linux 9.4.
22/04/2026 09:56:36 WARNING: The current system does not match with the list of recommended systems. The installation may not work properly.
22/04/2026 09:56:36 DEBUG: Detected distribution name: debian
22/04/2026 09:56:36 DEBUG: Detected distribution version: 12
22/04/2026 09:56:36 DEBUG: Installing check dependencies.
Get:1 file:/etc/apt/mirrors/debian.list Mirrorlist [38 B]
Get:2 file:/etc/apt/mirrors/debian-security.list Mirrorlist [47 B]
Hit:3 https://cdn-aws.deb.debian.org/debian bookworm InRelease
Hit:4 https://cdn-aws.deb.debian.org/debian bookworm-updates InRelease
Hit:5 https://cdn-aws.deb.debian.org/debian bookworm-backports InRelease
Hit:6 https://cdn-aws.deb.debian.org/debian-security bookworm-security InRelease
Reading package lists...
22/04/2026 09:56:38 INFO: --- Dependencies ----
22/04/2026 09:56:38 INFO: Installing gawk.
Reading package lists... Building dependency tree... Reading state information... The following package was automatically installed and is no longer required: libcurl4 Use 'sudo apt autoremove' to remove it. Suggested packages: gawk-doc The following NEW packages will be installed: gawk 0 upgraded, 1 newly installed, 0 to remove and 28 not upgraded. Need Processing triggers for man-db (2.11.2-2) ...4.deb ...ntly installed.)onal disk space will be used. Selecting previously unselected package gawk.
22/04/2026 09:56:39 INFO: Installing curl.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: curl 0 upgraded, 1 newly installed, 0 to remove an Processing triggers for man-db (2.11.2-2) ...14_amd64.deb ...stalled.)tion, 501 kB of additional disk space will be used. Selecting previously unselected package curl.
22/04/2026 09:56:40 DEBUG: The provided Filebeat template URL (https://raw.githubusercontent.com/wazuh/wazuh/v4.14.5/extensions/elasticsearch/7.x/wazuh-template.json) is not accessible. Trying with other URLs.
22/04/2026 09:56:41 DEBUG: Using Filebeat template from v4.14.5-rc1 tag.
22/04/2026 09:56:41 DEBUG: Checking system architecture.
22/04/2026 09:56:41 DEBUG: System architecture: x86_64
22/04/2026 09:56:41 WARNING: Hardware checks ignored.
22/04/2026 09:56:41 INFO: Wazuh web interface port will be 443.
22/04/2026 09:56:41 INFO: --- Dependencies ----
22/04/2026 09:56:41 INFO: Installing lsof.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: lsof 0 upgraded, 1 newly installed, 0 to remove an Processing triggers for man-db (2.11.2-2) ...eb ...rrently installed.)tion, 494 kB of additional disk space will be used. Selecting previously unselected package lsof.
22/04/2026 09:56:42 DEBUG: Checking ports availability.
Get:1 file:/etc/apt/mirrors/debian.list Mirrorlist [38 B]
Get:2 file:/etc/apt/mirrors/debian-security.list Mirrorlist [47 B]
Hit:3 https://cdn-aws.deb.debian.org/debian bookworm InRelease
Hit:4 https://cdn-aws.deb.debian.org/debian bookworm-updates InRelease
Hit:5 https://cdn-aws.deb.debian.org/debian bookworm-backports InRelease
Hit:6 https://cdn-aws.deb.debian.org/debian-security bookworm-security InRelease
Reading package lists...
22/04/2026 09:56:43 DEBUG: Installing prerequisites dependencies.
22/04/2026 09:56:45 DEBUG: Checking curl tool version.
22/04/2026 09:56:45 DEBUG: Adding the Wazuh repository.
gpg: keyring '/usr/share/keyrings/wazuh.gpg' created
gpg: key 96B3EE5F29111145: public key "Wazuh.com (Wazuh Signing Key) <support@wazuh.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main
Get:1 file:/etc/apt/mirrors/debian.list Mirrorlist [38 B]
Get:2 file:/etc/apt/mirrors/debian-security.list Mirrorlist [47 B]
Get:7 https://packages-dev.wazuh.com/pre-release/apt unstable InRelease [17.3 kB]
Hit:3 https://cdn-aws.deb.debian.org/debian bookworm InRelease
Hit:4 https://cdn-aws.deb.debian.org/debian bookworm-updates InRelease
Hit:5 https://cdn-aws.deb.debian.org/debian bookworm-backports InRelease
Hit:6 https://cdn-aws.deb.debian.org/debian-security bookworm-security InRelease
Get:8 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 Packages [52.1 kB]
Fetched 69.4 kB in 0s (210 kB/s)
Reading package lists...
22/04/2026 09:56:46 INFO: Wazuh development repository added.
22/04/2026 09:56:46 INFO: --- Configuration files ---
22/04/2026 09:56:46 INFO: Generating configuration files.
22/04/2026 09:56:46 DEBUG: Creating Wazuh certificates.
22/04/2026 09:56:46 DEBUG: Reading configuration file.
22/04/2026 09:56:46 DEBUG: Checking if 127.0.0.1 is private.
22/04/2026 09:56:46 DEBUG: Checking if 127.0.0.1 is private.
22/04/2026 09:56:46 DEBUG: Checking if 127.0.0.1 is private.
22/04/2026 09:56:46 INFO: Generating the root certificate.
22/04/2026 09:56:47 INFO: Generating Admin certificates.
22/04/2026 09:56:47 DEBUG: Generating Admin private key.
22/04/2026 09:56:47 DEBUG: Converting Admin private key to PKCS8 format.
22/04/2026 09:56:47 DEBUG: Generating Admin CSR.
22/04/2026 09:56:47 DEBUG: Creating Admin certificate.
22/04/2026 09:56:47 INFO: Generating Wazuh indexer certificates.
22/04/2026 09:56:47 DEBUG: Creating the certificates for wazuh-indexer indexer node.
22/04/2026 09:56:47 DEBUG: Generating certificate configuration.
22/04/2026 09:56:47 DEBUG: Creating the Wazuh indexer tmp key pair.
22/04/2026 09:56:47 DEBUG: Creating the Wazuh indexer certificates.
22/04/2026 09:56:47 INFO: Generating Filebeat certificates.
22/04/2026 09:56:47 DEBUG: Generating the certificates for wazuh-server server node.
22/04/2026 09:56:47 DEBUG: Generating certificate configuration.
22/04/2026 09:56:47 DEBUG: Creating the Wazuh server tmp key pair.
22/04/2026 09:56:47 DEBUG: Creating the Wazuh server certificates.
22/04/2026 09:56:47 INFO: Generating Wazuh dashboard certificates.
22/04/2026 09:56:47 DEBUG: Generating certificate configuration.
22/04/2026 09:56:47 DEBUG: Creating the Wazuh dashboard tmp key pair.
22/04/2026 09:56:48 DEBUG: Creating the Wazuh dashboard certificates.
22/04/2026 09:56:48 DEBUG: Cleaning certificate files.
22/04/2026 09:56:48 DEBUG: Generating password file.
22/04/2026 09:56:48 DEBUG: Generating random passwords.
22/04/2026 09:56:48 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
22/04/2026 09:56:48 DEBUG: Extracting Wazuh configuration.
22/04/2026 09:56:48 DEBUG: Reading configuration file.
22/04/2026 09:56:48 DEBUG: Checking if 127.0.0.1 is private.
22/04/2026 09:56:48 DEBUG: Checking if 127.0.0.1 is private.
22/04/2026 09:56:48 DEBUG: Checking if 127.0.0.1 is private.
22/04/2026 09:56:48 INFO: --- Wazuh indexer ---
22/04/2026 09:56:48 INFO: Starting Wazuh indexer installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-indexer 0 upgraded, 1 newly installed, 0 to remove and 28 not upgraded. Need to get 874 MB of archives. After this operation, 1103 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/ sudo systemctl start wazuh-indexer.service executing following statements to configure wazuh-indexer service to start automatically using systemdxer.
22/04/2026 09:57:08 DEBUG: Checking Wazuh installation.
22/04/2026 09:57:08 DEBUG: There are Wazuh indexer remaining files.
22/04/2026 09:57:08 INFO: Wazuh indexer installation finished.
22/04/2026 09:57:08 DEBUG: Configuring Wazuh indexer.
22/04/2026 09:57:08 DEBUG: Copying Wazuh indexer certificates.
22/04/2026 09:57:09 INFO: Wazuh indexer post-install configuration finished.
22/04/2026 09:57:09 INFO: Starting service wazuh-indexer.
Synchronizing state of wazuh-indexer.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable wazuh-indexer
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.
22/04/2026 09:57:21 INFO: wazuh-indexer service started.
22/04/2026 09:57:21 INFO: Initializing Wazuh indexer cluster security settings.
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.19.5
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","actiongroups","config","internalusers"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","actiongroups","config","internalusers"]) due to: null
Done with success
22/04/2026 09:57:24 INFO: Wazuh indexer cluster security configuration initialized.
22/04/2026 09:57:24 INFO: Wazuh indexer cluster initialized.
22/04/2026 09:57:24 INFO: --- Wazuh server ---
22/04/2026 09:57:24 INFO: Starting the Wazuh manager installation.
Reading package lists... Building dependency tree... Reading state information... Suggested packages: expect The following NEW packages will be installed: wazuh-manager 0 upgraded, 1 newly installed, 0 to remove and 28 not upgraded. Need to get 499 MB of archives. After this operation, 1089 MB of additional disk space will be used. Get:1 https://packages Setting up wazuh-manager (4.14.5-1) ....14.5-1_amd64.deb ...nstalled.)4.14.5-1 [499 MB] Fetched 499 MB in 6s (83.5 MB/s) Selecting previously unselected package wazuh-manager.
22/04/2026 09:58:29 DEBUG: Checking Wazuh installation.
22/04/2026 09:58:29 DEBUG: There are Wazuh remaining files.
22/04/2026 09:58:29 DEBUG: There are Wazuh indexer remaining files.
22/04/2026 09:58:30 INFO: Wazuh manager installation finished.
22/04/2026 09:58:30 DEBUG: Configuring Wazuh manager.
22/04/2026 09:58:30 DEBUG: Setting provisional Wazuh indexer password.
22/04/2026 09:58:30 INFO: Wazuh manager vulnerability detection configuration finished.
22/04/2026 09:58:30 INFO: Starting service wazuh-manager.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.
22/04/2026 09:58:42 INFO: wazuh-manager service started.
22/04/2026 09:58:42 INFO: Starting Filebeat installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: filebeat 0 upgraded, 1 newly installed, 0 to remove and 28 not upgraded. Need to get 22.1 MB of archives. After this operation, 73.6 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt  Setting up filebeat (7.10.2-2) ....10.2-2_amd64.deb ...tly installed.)n 0s (65.8 MB/s) Selecting previously unselected package filebeat.
22/04/2026 09:58:49 DEBUG: Checking Wazuh installation.
22/04/2026 09:58:49 DEBUG: There are Wazuh remaining files.
22/04/2026 09:58:49 DEBUG: There are Wazuh indexer remaining files.
22/04/2026 09:58:49 DEBUG: There are Filebeat remaining files.
22/04/2026 09:58:50 INFO: Filebeat installation finished.
22/04/2026 09:58:50 DEBUG: Configuring Filebeat.
22/04/2026 09:58:50 DEBUG: Filebeat template was download successfully.
wazuh/
wazuh/alerts/
wazuh/alerts/manifest.yml
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/archives/
wazuh/archives/manifest.yml
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/_meta/
wazuh/_meta/config.yml
wazuh/_meta/fields.yml
wazuh/_meta/docs.asciidoc
wazuh/module.yml
22/04/2026 09:58:50 DEBUG: Filebeat module was downloaded successfully.
22/04/2026 09:58:50 DEBUG: Copying Filebeat certificates.
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
22/04/2026 09:58:50 INFO: Filebeat post-install configuration finished.
22/04/2026 09:58:50 INFO: Starting service filebeat.
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.
22/04/2026 09:58:52 INFO: filebeat service started.
22/04/2026 09:58:52 INFO: --- Wazuh dashboard ---
22/04/2026 09:58:52 INFO: Starting Wazuh dashboard installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-dashboard 0 upgraded, 1 newly installed, 0 to remove and 28 not upgraded. Need to get 195 MB of archives. After this operation, 1052 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-releas Setting up wazuh-dashboard (4.14.5-1) ....14.5-1_amd64.deb ...talled.)ed 195 MB in 3s (72.3 MB/s) Selecting previously unselected package wazuh-dashboard.
22/04/2026 10:01:29 DEBUG: Checking Wazuh installation.
22/04/2026 10:01:30 DEBUG: There are Wazuh remaining files.
22/04/2026 10:01:30 DEBUG: There are Wazuh indexer remaining files.
22/04/2026 10:01:30 DEBUG: There are Filebeat remaining files.
22/04/2026 10:01:30 DEBUG: There are Wazuh dashboard remaining files.
22/04/2026 10:01:30 INFO: Wazuh dashboard installation finished.
22/04/2026 10:01:30 DEBUG: Configuring Wazuh dashboard.
22/04/2026 10:01:30 DEBUG: Copying Wazuh dashboard certificates.
22/04/2026 10:01:31 DEBUG: Wazuh dashboard certificate setup finished.
22/04/2026 10:01:31 INFO: Wazuh dashboard post-install configuration finished.
22/04/2026 10:01:31 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
22/04/2026 10:01:32 INFO: wazuh-dashboard service started.
22/04/2026 10:01:32 DEBUG: Setting Wazuh indexer cluster passwords.
22/04/2026 10:01:32 DEBUG: Checking Wazuh installation.
22/04/2026 10:01:32 DEBUG: There are Wazuh remaining files.
22/04/2026 10:01:32 DEBUG: There are Wazuh indexer remaining files.
22/04/2026 10:01:32 DEBUG: There are Filebeat remaining files.
22/04/2026 10:01:33 DEBUG: There are Wazuh dashboard remaining files.
22/04/2026 10:01:33 INFO: Updating the internal users.
22/04/2026 10:01:33 DEBUG: Creating password backup.
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.19.5
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
22/04/2026 10:01:36 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
22/04/2026 10:01:36 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
22/04/2026 10:01:36 DEBUG: The internal users have been updated before changing the passwords.
22/04/2026 10:01:37 DEBUG: Generating password hashes.
22/04/2026 10:01:43 DEBUG: Password hashes generated.
22/04/2026 10:01:43 DEBUG: Creating password backup.
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.19.5
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
22/04/2026 10:01:45 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
Successfully updated the keystore
Successfully updated the keystore
22/04/2026 10:01:46 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
22/04/2026 10:01:46 DEBUG: Restarting filebeat service...
22/04/2026 10:01:46 DEBUG: filebeat started.
22/04/2026 10:01:46 DEBUG: Restarting wazuh-manager service...
22/04/2026 10:02:03 DEBUG: wazuh-manager started.
22/04/2026 10:02:05 DEBUG: Restarting wazuh-dashboard service...
22/04/2026 10:02:05 DEBUG: wazuh-dashboard started.
22/04/2026 10:02:05 DEBUG: Running security admin tool.
22/04/2026 10:02:05 DEBUG: Loading new passwords changes.
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.19.5
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /home/admin
Force type: internalusers
Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
Done with success
22/04/2026 10:02:08 DEBUG: Passwords changed.
22/04/2026 10:02:08 DEBUG: Changing API passwords.
22/04/2026 10:02:15 INFO: Initializing Wazuh dashboard web application.
22/04/2026 10:02:15 INFO: Wazuh dashboard web application not yet initialized. Waiting...
22/04/2026 10:02:32 INFO: Wazuh dashboard web application not yet initialized. Waiting...
22/04/2026 10:02:47 INFO: Wazuh dashboard web application initialized.
22/04/2026 10:02:47 INFO: --- Summary ---
22/04/2026 10:02:47 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: 8.UIvylDi6vE05KVFPS0nguHKbGBilJN
22/04/2026 10:02:47 INFO: --- Dependencies ----
22/04/2026 10:02:47 INFO: Removing gawk.
Reading package lists... Building dependency tree... Reading state information... The following package was automatically installed and is no longer required: libsigsegv2 Use 'sudo apt autoremove' to remove it. The following packages will be REMOVED: gawk* 0 upgraded, 0 newly installed, 1 to remove and 28 not upgraded. After this operation, 2976 kB disk  Purging configuration files for gawk (1:5.2.1-2) ...rrently installed.)in auto mode
22/04/2026 10:03:00 DEBUG: Skipping removal of curl: it is also a Wazuh component dependency.
22/04/2026 10:03:00 INFO: Removing lsof.
Reading package lists... Building dependency tree... Reading state information... The following package was automatically installed and is no longer required: libsigsegv2 Use 'sudo apt autoremove' to remove it. The following packages will be REMOVED: lsof* 0 upgraded, 0 newly installed, 1 to remove and 28 not upgraded. After this operation, 494 kB disk s Processing triggers for man-db (2.11.2-2) ...ries currently installed.)
22/04/2026 10:03:05 DEBUG: Restoring Wazuh repository.
22/04/2026 10:03:05 INFO: Installation finished.
```

</details>
