### PR TITLE
Changed `config.yml` template to show only ip keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Changed config.yml template to show only ip keys ([#717](https://github.com/wazuh/wazuh-installation-assistant/pull/717))
 - Adapted the config.yml component names to match the default certificate names. ([#679](https://github.com/wazuh/wazuh-installation-assistant/pull/679))
 - Updated GitHub actions version for wazuh-installation-assistant main workflows. ([#678](https://github.com/wazuh/wazuh-installation-assistant/pull/678))
 - Change wazuh-manager certs folder ownership to wazuh-manager ([#676](https://github.com/wazuh/wazuh-installation-assistant/pull/676))

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ As an alternative to downloading, use the `builder.sh` script to build the Wazuh
 
 Start by downloading the [configuration file](https://packages.wazuh.com/production/5.x/installation-assistant/config.yml) and replace the node names and IP values with the corresponding ones.
 
+For DNS-based or mixed address configurations, see [Other `config.yml` examples](docs/ref/configuration/configuration-files.md#other-configyml-examples).
+
 > [!NOTE]
 > It is not necessary to download the Wazuh passwords tool and the Wazuh cert tool to use the Wazuh installation assistant. The Wazuh installation assistant has embedded the previous tools.
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,6 +20,10 @@
   - [Certs Tool Installation](ref/installation/certs-tool/certs-tool-installation.md)
   - [Passwords Tool Installation](ref/installation/passwords-tool/passwords-tool-installation.md)
   - [Installation Assistant Installation](ref/installation/installation-assistant/ia-installation.md)
+- [Configuration](ref/configuration/README.md)
+  - [Command line options](ref/configuration/command-line-options.md)
+  - [Configuration files](ref/configuration/configuration-files.md)
+  - [Environment variables](ref/configuration/environment-variables.md)
 
 # Guide
 

--- a/docs/guide/installation-assistant-deployments/clusterized.md
+++ b/docs/guide/installation-assistant-deployments/clusterized.md
@@ -28,19 +28,18 @@ Follow these steps to configure your Wazuh deployment, create SSL certificates t
 
   2. Edit `./config.yml` and replace the node names and IP values with the corresponding names and IP addresses. You need to do this for all Wazuh manager, Wazuh indexer, and Wazuh dashboard nodes. Add as many node fields as needed.
 
+  For DNS-based or mixed address configurations, see [Other `config.yml` examples](../../ref/configuration/configuration-files.md#other-configyml-examples).
+
 ```yaml
 nodes:
   # Wazuh indexer nodes
   indexer:
     - name: indexer
       ip: "<indexer-node-ip>"
-    #  dns: "<indexer-node-dns>"
     #- name: indexer-2
-    #  dns: "<indexer-node-dns>"
+    #  ip: "<indexer-node-ip>"
     #- name: indexer-3
     #  ip: "<indexer-node-ip>"
-    #  dns:
-    #    - "<indexer-node-dns>"
 
   # Wazuh manager nodes
   # If there is more than one Wazuh manager
@@ -48,22 +47,18 @@ nodes:
   manager:
     - name: manager
       ip: "<wazuh-manager-ip>"
-    #  dns: "<wazuh-manager-dns>"
     #  node_type: master
     #- name: manager-2
-    #  dns: "<wazuh-manager-dns>"
+    #  ip: "<wazuh-manager-ip>"
     #  node_type: worker
     #- name: manager-3
     #  ip: "<wazuh-manager-ip>"
-    #  dns:
-    #    - "<wazuh-manager-dns>"
     #  node_type: worker
 
   # Wazuh dashboard nodes
   dashboard:
     - name: dashboard
       ip: "<dashboard-node-ip>"
-    #  dns: "<dashboard-node-dns>"
 ```
 
   3. Run the Wazuh installation assistant with the option `--generate-config-files` to generate the Wazuh cluster key, certificates, and passwords necessary for installation. You can find these files in `./wazuh-install-files.tar`.

--- a/docs/guide/offline-download-packages/offline-download-packages.md
+++ b/docs/guide/offline-download-packages/offline-download-packages.md
@@ -61,6 +61,8 @@ curl -s -o config.yml https://packages.wazuh.com/production/5.x/config-5.0.0.yml
 - If you are performning an all-in-one deployment, replace the `"<indexer-node-ip>"`, `"<wazuh-manager-ip>"`, and `"<dashboard-node-ip>"` with `127.0.0.1`.
 - If you are performing a distributed deployment, replace the node names and IP values with the corresponding names and IP addresses. You need to do this for all the Wazuh server, Wazuh indexer, and Wazuh dashboard nodes. Add as many node fields as needed.
 
+For DNS-based or mixed address configurations, see [Other `config.yml` examples](../../ref/configuration/configuration-files.md#other-configyml-examples).
+
 ### 5. Create the certificates
 
 Run the following command in order to create the certificates using the installation assistant script.

--- a/docs/guide/offline-installation-assistant-deployments/offline-assisted-install.md
+++ b/docs/guide/offline-installation-assistant-deployments/offline-assisted-install.md
@@ -83,6 +83,8 @@ The following dependencies must be installed on the Wazuh indexer nodes:
 
 1. Run the multi-node assisted method with the `--offline-installation` flag to perform an offline installation. Use the option `--wazuh-indexer` and the node name to install and configure the Wazuh indexer. The node name must be the same one used in `config.yml` for the initial configuration, for example, `indexer`.
 
+    For DNS-based or mixed address configurations, see [Other `config.yml` examples](../../ref/configuration/configuration-files.md#other-configyml-examples).
+
     ```bash
     bash wazuh-install-5.0.0.sh --offline-installation --wazuh-indexer indexer
     ```

--- a/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md
+++ b/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md
@@ -31,6 +31,8 @@ The following dependencies must be installed on the Wazuh indexer nodes:
 
 2. Run the following commands replacing `<INDEXER_NODE_NAME>` with the name of the Wazuh indexer node you are configuring as defined in `config.yml`. For example, `indexer`. This deploys the SSL certificates to encrypt communications between the Wazuh central components.
 
+    For DNS-based or mixed address configurations, see [Other `config.yml` examples](../../ref/configuration/configuration-files.md#other-configyml-examples).
+
     ```bash
     NODE_NAME=<INDEXER_NODE_NAME>
     mkdir /etc/wazuh-indexer/certs

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -6,6 +6,8 @@ This section describes the security mechanisms used by the Wazuh installation to
 
 All communication between Wazuh components (Indexer, Manager, and Dashboard) is encrypted using SSL/TLS certificates. Certificates are generated with the `wazuh-certs-tool-5.0.0.sh` script based on the node information in `config.yml`.
 
+For DNS-based or mixed address configurations in `config.yml`, see [Other `config.yml` examples](../ref/configuration/configuration-files.md#other-configyml-examples).
+
 The certificate bundle (`wazuh-install-files.tar`) is created once and then distributed to each node. It contains:
 
 - A root CA certificate (`root-ca.pem` and `root-ca.key`)

--- a/docs/guide/step-by-step-deployments/all-in-one.md
+++ b/docs/guide/step-by-step-deployments/all-in-one.md
@@ -18,6 +18,8 @@ Wazuh uses certificates to establish confidentiality and encrypt communications 
 
   2. Edit `config.yml` and replace the node names and IP values with the corresponding names and IP addresses. In this case, the IP to configure can be `127.0.0.1` since we are performing an All-In-One installation.
 
+  For DNS-based or mixed address configurations, see [Other `config.yml` examples](../../ref/configuration/configuration-files.md#other-configyml-examples).
+
   ```yaml
   nodes:
   # Wazuh indexer node

--- a/docs/guide/step-by-step-deployments/clusterized.md
+++ b/docs/guide/step-by-step-deployments/clusterized.md
@@ -19,6 +19,8 @@ Wazuh uses certificates to establish confidentiality and encrypt communications 
 
   2. Edit `config.yml` and replace the node names and IP values with the corresponding names and IP addresses. You need to do this for all Wazuh manager, Wazuh indexer, and Wazuh dashboard nodes. Add as many node fields as needed.
 
+  For DNS-based or mixed address configurations, see [Other `config.yml` examples](../../ref/configuration/configuration-files.md#other-configyml-examples).
+
   ```yaml
 nodes:
   # Wazuh indexer nodes

--- a/docs/ref/configuration/command-line-options.md
+++ b/docs/ref/configuration/command-line-options.md
@@ -30,6 +30,8 @@ The Wazuh Installation Assistant is used by running the previously downloaded `w
 
 The certs-tool is used by running the previously downloaded `wazuh-certs-tool-5.0.0.sh` script along with the `config.yml` configuration file. The certs tool generates the necessary certificates for the nodes specified in the configuration file.
 
+For DNS-based or mixed address configurations, see [Other `config.yml` examples](configuration-files.md#other-configyml-examples).
+
 ### Options list
 
 | Option | Description |

--- a/docs/ref/configuration/configuration-files.md
+++ b/docs/ref/configuration/configuration-files.md
@@ -54,7 +54,7 @@ The steps to perform the installation are as follows:
 The `config.yml` file is a YAML format configuration file that contains the necessary information to generate certificates for Wazuh nodes.
 It is very important to ensure that the `config.yml` file is correctly configured with both the name of each node and the IP address, as they will be used to generate the corresponding certificate.
 
-Here is a basic example of how this file should be structured:
+Here is the default example of how this file should be structured (using only `ip`):
 
 ```yaml
 nodes:
@@ -62,13 +62,10 @@ nodes:
   indexer:
     - name: indexer
       ip: "<indexer-node-ip>"
-    #  dns: "<indexer-node-dns>"
     #- name: indexer-2
-    #  dns: "<indexer-node-dns>"
+    #  ip: "<indexer-node-ip>"
     #- name: indexer-3
     #  ip: "<indexer-node-ip>"
-    #  dns:
-    #    - "<indexer-node-dns>"
 
   # Wazuh manager nodes
   # If there is more than one Wazuh manager
@@ -76,28 +73,110 @@ nodes:
   manager:
     - name: manager
       ip: "<wazuh-manager-ip>"
-    #  dns: "<wazuh-manager-dns>"
     #  node_type: master
     #- name: manager-2
-    #  dns: "<wazuh-manager-dns>"
+    #  ip: "<wazuh-manager-ip>"
     #  node_type: worker
     #- name: manager-3
     #  ip: "<wazuh-manager-ip>"
-    #  dns:
-    #    - "<wazuh-manager-dns>"
     #  node_type: worker
 
   # Wazuh dashboard nodes
   dashboard:
     - name: dashboard
       ip: "<dashboard-node-ip>"
-    #  dns: "<dashboard-node-dns>"
 ```
 
-Each node must have a unique name and an associated IP address. In the case of Wazuh server nodes, if there is more than one node, it is necessary to specify the node type (master or worker) using the `node_type` field.
+### Other `config.yml` examples
 
-For the certs-tool to detect the file, it must be located in the same path as the `wazuh-certs-tool-5.0.0.sh` script.
+Each node must have a unique name and at least one network identifier (`ip` or `dns`). In the case of Wazuh manager nodes, if there is more than one node, it is necessary to specify the node type (master or worker) using the `node_type` field.
 
-## Wazuh password tool
+#### Example 1: using only `dns` values
 
-The wazuh password tool does not accept configuration files for use.
+```yaml
+nodes:
+  indexer:
+    - name: indexer-1
+      dns: "indexer-1.example.org"
+
+  manager:
+    - name: manager-1
+      dns: "manager-1.example.org"
+      node_type: master
+    - name: manager-2
+      dns: "manager-2.example.org"
+      node_type: worker
+
+  dashboard:
+    - name: dashboard-1
+      dns: "dashboard.example.org"
+```
+
+#### Example 2: using only DNS lists
+
+```yaml
+nodes:
+  indexer:
+    - name: indexer-1
+      dns:
+        - "indexer-1.example.org"
+        - "indexer-1.internal.local"
+
+  manager:
+    - name: manager-1
+      dns:
+        - "manager-1.example.org"
+        - "manager-1.internal.local"
+      node_type: master
+    - name: manager-2
+      dns:
+        - "manager-2.example.org"
+        - "manager-2.internal.local"
+      node_type: worker
+
+  dashboard:
+    - name: dashboard-1
+      dns:
+        - "dashboard.example.org"
+        - "dashboard.internal.local"
+```
+
+#### Example 3: combining `ip`, `dns`, and DNS lists
+
+```yaml
+nodes:
+  indexer:
+    - name: indexer-by-ip
+      ip: "10.0.0.11"
+    - name: indexer-by-dns
+      dns: "indexer.example.org"
+    - name: indexer-by-dns-list
+      dns:
+        - "indexer.example.org"
+        - "indexer.internal.local"
+    - name: indexer-combined
+      ip: "10.0.0.12"
+      dns:
+        - "indexer-alt.example.org"
+
+  manager:
+    - name: manager-by-ip
+      ip: "10.0.0.21"
+      node_type: master
+    - name: manager-combined
+      ip: "10.0.0.22"
+      dns: "manager.example.org"
+      node_type: worker
+
+  dashboard:
+    - name: dashboard-by-dns
+      dns: "dashboard.example.org"
+```
+
+By default, documentation examples use only `ip` values for simplicity.
+
+For the wazuh certs tool to detect the file, it must be located in the same path as the `wazuh-certs-tool-5.0.0.sh` script.
+
+## Wazuh passwords tool
+
+The wazuh passwords tool does not accept configuration files for use.

--- a/docs/ref/getting-started/usage.md
+++ b/docs/ref/getting-started/usage.md
@@ -44,6 +44,8 @@ If you want to install a specific Wazuh component, first make sure you have the 
 
 The `config.yml` file is a YAML format configuration file that contains the name and IP of each component to be installed in the distributed installation. This file is used to generate the necessary certificates for secure communication between the different Wazuh components. For more information on how to configure this file, see the [certs-tool-usage.md](../certs-tool/certs-tool-usage.md) section.
 
+For additional `config.yml` formats (`dns`, DNS lists, and mixed configurations), see [Other `config.yml` examples](../configuration/configuration-files.md#other-configyml-examples).
+
 The steps to perform the installation are as follows:
 > **note**: If you have already configured the `config.yml` and generated the `wazuh-install-files.tar` in the installation of another Wazuh component, you can skip directly to step 4.
 
@@ -107,6 +109,8 @@ See the [Installation Assistant Installation](../../installation/installation-as
     This command will generate the `wazuh-offline.tar.gz` file which contains all the packages necessary to install Wazuh on the offline system.
 
 2. Next, create the necessary certificates that will be used in the offline installation. To do this, modify the `config.yml` file with the desired configuration for each of the Wazuh components and run the following command:
+
+  If you need DNS-based configurations, see [Other `config.yml` examples](../configuration/configuration-files.md#other-configyml-examples).
 
     ```bash
     sudo bash wazuh-install-5.0.0.sh --generate-config-files
@@ -211,13 +215,10 @@ nodes:
   indexer:
     - name: indexer
       ip: "<indexer-node-ip>"
-    #  dns: "<indexer-node-dns>"
     #- name: indexer-2
-    #  dns: "<indexer-node-dns>"
+    #  ip: "<indexer-node-ip>"
     #- name: indexer-3
     #  ip: "<indexer-node-ip>"
-    #  dns:
-    #    - "<indexer-node-dns>"
 
   # Wazuh manager nodes
   # If there is more than one Wazuh manager
@@ -225,22 +226,18 @@ nodes:
   manager:
     - name: manager
       ip: "<wazuh-manager-ip>"
-    #  dns: "<wazuh-manager-dns>"
     #  node_type: master
     #- name: manager-2
-    #  dns: "<wazuh-manager-dns>"
+    #  ip: "<wazuh-manager-ip>"
     #  node_type: worker
     #- name: manager-3
     #  ip: "<wazuh-manager-ip>"
-    #  dns:
-    #    - "<wazuh-manager-dns>"
     #  node_type: worker
 
   # Wazuh dashboard nodes
   dashboard:
     - name: dashboard
       ip: "<dashboard-node-ip>"
-    #  dns: "<dashboard-node-dns>"
 ```
 
 Each node must have a unique name and an associated IP address. In the case of Wazuh server nodes, if there is more than one node, it is necessary to specify the node type (master or worker) using the `node_type` field.

--- a/docs/ref/glossary.md
+++ b/docs/ref/glossary.md
@@ -86,6 +86,8 @@ A shared secret key used to authenticate and secure communication between nodes 
 
 The main configuration file that defines the deployment architecture, including node names, IP addresses or DNS names, and node types for each component. Required for generating certificates and for distributed deployments. Should be customized before installation.
 
+For supported `config.yml` formats using `ip`, `dns`, DNS lists, or mixed values, see [Other `config.yml` examples](configuration/configuration-files.md#other-configyml-examples).
+
 ### internal_users.yml
 
 A configuration file in Wazuh Indexer that defines internal users and their hashed passwords. Modified by the Wazuh Password Tool when updating user credentials.

--- a/docs/ref/installation/certs-tool/certs-tool-installation.md
+++ b/docs/ref/installation/certs-tool/certs-tool-installation.md
@@ -8,6 +8,8 @@ curl -sO https://packages.wazuh.com/production/5.x/installation-assistant/wazuh-
 
 For the certs-tool, the `config.yml` configuration file is also necessary, which can be downloaded with the following command:
 
+For DNS-based or mixed address configurations, see [Other `config.yml` examples](../../configuration/configuration-files.md#other-configyml-examples).
+
 ```bash
 curl -s -o config.yml https://packages.wazuh.com/production/5.x/installation-assistant/config-5.0.0.yml
 ```

--- a/docs/ref/installation/installation-assistant/ia-installation.md
+++ b/docs/ref/installation/installation-assistant/ia-installation.md
@@ -8,6 +8,8 @@ curl -sO https://packages.wazuh.com/production/5.x/installation-assistant/wazuh-
 
 If you want to perform an installation of a specific component, you must also download the config-.yml file with:
 
+For DNS-based or mixed address configurations, see [Other `config.yml` examples](../../configuration/configuration-files.md#other-configyml-examples).
+
 ```bash
 curl -s -o config.yml https://packages.wazuh.com/production/5.x/installation-assistant/config-5.0.0.yml
 ```

--- a/docs/ref/introduction/description.md
+++ b/docs/ref/introduction/description.md
@@ -16,4 +16,6 @@ The script is written in bash and creates secure passwords for different users, 
 
 The `wazuh-certs-tool-5.0.0.sh` script simplifies certificate generation for Wazuh central components and creates all the certificates required for installation.You need to create or edit the configuration file config.yml. This file references the node details like node types and IP addresses or DNS names which are used to generate certificates for each of the nodes specified in it.
 
+For `config.yml` variants using `dns`, DNS lists, or mixed values, see [Other `config.yml` examples](../configuration/configuration-files.md#other-configyml-examples).
+
 The script is written in bash and creates all certificates needed for deploy Wazuh central components. Use openssl to create 2048-bit and sha256 certificates.

--- a/docs/ref/tests/integration-test/integration-tests.md
+++ b/docs/ref/tests/integration-test/integration-tests.md
@@ -105,6 +105,8 @@ After installation the workflow waits for the Wazuh dashboard to respond at `htt
 
 Each Wazuh component is installed in a separate step on the same node. This mode tests the distributed installation code paths — certificate generation from `config.yml`, component-by-component installation, and indexer cluster security initialization.
 
+For DNS-based or mixed address configurations, see [Other `config.yml` examples](../../configuration/configuration-files.md#other-configyml-examples).
+
 A `config.yml` file with `127.0.0.1` as the IP for all three nodes is generated and transferred to the instance before installation:
 
 ```yaml

--- a/documentation-templates/wazuh/config.yml
+++ b/documentation-templates/wazuh/config.yml
@@ -3,13 +3,10 @@ nodes:
   indexer:
     - name: indexer
       ip: "<indexer-node-ip>"
-    #  dns: "<indexer-node-dns>"
     #- name: indexer-2
-    #  dns: "<indexer-node-dns>"
+    #  ip: "<indexer-node-ip>"
     #- name: indexer-3
     #  ip: "<indexer-node-ip>"
-    #  dns:
-    #    - "<indexer-node-dns>"
 
   # Wazuh manager nodes
   # If there is more than one Wazuh manager
@@ -17,19 +14,15 @@ nodes:
   manager:
     - name: manager
       ip: "<wazuh-manager-ip>"
-    #  dns: "<wazuh-manager-dns>"
     #  node_type: master
     #- name: manager-2
-    #  dns: "<wazuh-manager-dns>"
+    #  ip: "<wazuh-manager-ip>"
     #  node_type: worker
     #- name: manager-3
     #  ip: "<wazuh-manager-ip>"
-    #  dns:
-    #    - "<wazuh-manager-dns>"
     #  node_type: worker
 
   # Wazuh dashboard nodes
   dashboard:
     - name: dashboard
       ip: "<dashboard-node-ip>"
-    #  dns: "<dashboard-node-dns>"


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-installation-assistant/issues/694

# Description

The aim of this PR is to change the template `config.yml` file to show only `ip` keys as a basic example.

<details>
<summary>Final config.yml file:</summary>

```yaml
nodes:
  # Wazuh indexer nodes
  indexer:
    - name: indexer
      ip: "<indexer-node-ip>"
    #- name: indexer-2
    #  ip: "<indexer-node-ip>"
    #- name: indexer-3
    #  ip: "<indexer-node-ip>"

  # Wazuh manager nodes
  # If there is more than one Wazuh manager
  # node, each one must have a node_type
  manager:
    - name: manager
      ip: "<wazuh-manager-ip>"
    #  node_type: master
    #- name: manager-2
    #  ip: "<wazuh-manager-ip>"
    #  node_type: worker
    #- name: manager-3
    #  ip: "<wazuh-manager-ip>"
    #  node_type: worker

  # Wazuh dashboard nodes
  dashboard:
    - name: dashboard
      ip: "<dashboard-node-ip>"
```

</details>

---

In addition, three more examples of `config.yml` files have been included in the documentation.

These, examples are the following:

#### 1. Using only `dns` values

<details>
<summary>Example:</summary>

```yaml
nodes:
  indexer:
    - name: indexer-1
      dns: "indexer-1.example.org"

  manager:
    - name: manager-1
      dns: "manager-1.example.org"
      node_type: master
    - name: manager-2
      dns: "manager-2.example.org"
      node_type: worker

  dashboard:
    - name: dashboard-1
      dns: "dashboard.example.org"
```

</details>

#### 2. Using only DNS lists

<details>
<summary>Example:</summary>

```yaml
nodes:
  indexer:
    - name: indexer-1
      dns:
        - "indexer-1.example.org"
        - "indexer-1.internal.local"

  manager:
    - name: manager-1
      dns:
        - "manager-1.example.org"
        - "manager-1.internal.local"
      node_type: master
    - name: manager-2
      dns:
        - "manager-2.example.org"
        - "manager-2.internal.local"
      node_type: worker

  dashboard:
    - name: dashboard-1
      dns:
        - "dashboard.example.org"
        - "dashboard.internal.local"
```

</details>

#### 3. Combining `ip`, `dns`, and DNS lists

<details>
<summary>Example:</summary>

```yaml
nodes:
  indexer:
    - name: indexer-by-ip
      ip: "10.0.0.11"
    - name: indexer-by-dns
      dns: "indexer.example.org"
    - name: indexer-by-dns-list
      dns:
        - "indexer.example.org"
        - "indexer.internal.local"
    - name: indexer-combined
      ip: "10.0.0.12"
      dns:
        - "indexer-alt.example.org"

  manager:
    - name: manager-by-ip
      ip: "10.0.0.21"
      node_type: master
    - name: manager-combined
      ip: "10.0.0.22"
      dns: "manager.example.org"
      node_type: worker

  dashboard:
    - name: dashboard-by-dns
      dns: "dashboard.example.org"
```

</details>

---

The `SUMMARY.md` has been updated accordingly to include these sections that were missing.