### PR TITLE
A validation for the status of services is added to the password tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- A validation for the status of services is added to the password tool. ([#786](https://github.com/wazuh/wazuh-installation-assistant/pull/786))
 - Added repository download documentation ([#783](https://github.com/wazuh/wazuh-installation-assistant/pull/783))
 - Fix offline dependency installation for Amazon Linux 2023 ([#782](https://github.com/wazuh/wazuh-installation-assistant/pull/782))
 - Add 5.x bumper revert changes ([#727](https://github.com/wazuh/wazuh-installation-assistant/pull/727))

--- a/passwords_tool/passwordsFunctions.sh
+++ b/passwords_tool/passwordsFunctions.sh
@@ -42,7 +42,11 @@ function passwords_changePassword() {
                 conf="$(awk '{sub("opensearch.password: .*", "opensearch.password: '"${dashpass}"'")}1' /etc/wazuh-dashboard/opensearch_dashboards.yml)"
                 echo "${conf}" > /etc/wazuh-dashboard/opensearch_dashboards.yml
             fi
-            passwords_restartService "wazuh-dashboard"
+            if passwords_isServiceActive "wazuh-dashboard"; then
+                passwords_restartService "wazuh-dashboard"
+            else
+                common_logger -d "wazuh-dashboard service is not running. Skipping restart."
+            fi
         fi
     fi
 
@@ -51,6 +55,10 @@ function passwords_changePassword() {
 function passwords_changePasswordApi() {
     # Change API password tool
     if [ -n "${wazuh_installed}" ]; then
+        if ! passwords_isServiceActive "wazuh-manager"; then
+            common_logger -e "wazuh-manager service is not running. Skipping API password change for user ${nuser}."
+            exit 1;
+        fi
         passwords_getApiUserId "${nuser}"
         WAZUH_PASS_API='{\"password\":\"'"${password}"'\"}'
         common_curl -s -k -X PUT -H \"Authorization: Bearer $TOKEN_API\" -H \"Content-Type: application/json\" -d "$WAZUH_PASS_API" "https://localhost:55000/security/users/${user_id}" -o /dev/null --max-time 300 --retry 5 --retry-delay 5 --fail
@@ -165,6 +173,11 @@ function passwords_getApiToken() {
     retries=0
     max_internal_error_retries=20
 
+    if ! passwords_isServiceActive "wazuh-manager"; then
+        common_logger -e "wazuh-manager service is not running. Skipping API password change for user ${nuser}."
+        exit 1;
+    fi
+
     TOKEN_API=$(curl -s -u "${adminUser}":"${adminPassword}" -k -X POST "https://localhost:55000/security/user/authenticate?raw=true" --max-time 300 --retry 5 --retry-delay 5)
     while [[ "${TOKEN_API}" =~ "Wazuh Internal Error" ]] && [ "${retries}" -lt "${max_internal_error_retries}" ]
     do
@@ -191,12 +204,22 @@ function passwords_getApiToken() {
 
 function passwords_getApiUsers() {
 
-    mapfile -t api_users < <(common_curl -s -k -X GET -H \"Authorization: Bearer $TOKEN_API\" -H \"Content-Type: application/json\"  \"https://localhost:55000/security/users?pretty=true\" --max-time 300 --retry 5 --retry-delay 5 | grep username | awk -F': ' '{print $2}' | sed -e "s/[\'\",]//g")
+    if passwords_isServiceActive "wazuh-manager"; then
+        mapfile -t api_users < <(common_curl -s -k -X GET -H \"Authorization: Bearer $TOKEN_API\" -H \"Content-Type: application/json\"  \"https://localhost:55000/security/users?pretty=true\" --max-time 300 --retry 5 --retry-delay 5 | grep username | awk -F': ' '{print $2}' | sed -e "s/[\'\",]//g")
+    else
+        common_logger -e "wazuh-manager service is not running. Skipping API password change for user ${nuser}."
+        exit 1;
+    fi
 
 }
 
 function passwords_getApiUserId() {
-    user_id=$(common_curl -s -k -H \"Authorization: Bearer $TOKEN_API\" -H \"Content-Type: application/json\" \"https://localhost:55000/security/users?pretty=true\" | grep -B2 -A2 "\"username\": \"${1}\"" | grep '"id"' | grep -o '[0-9]\+')
+    if passwords_isServiceActive "wazuh-manager"; then
+        user_id=$(common_curl -s -k -H \"Authorization: Bearer $TOKEN_API\" -H \"Content-Type: application/json\" \"https://localhost:55000/security/users?pretty=true\" | grep -B2 -A2 "\"username\": \"${1}\"" | grep '"id"' | grep -o '[0-9]\+')
+    else
+        common_logger -e "wazuh-manager service is not running. Skipping API password change for user ${nuser}."
+        exit 1;
+    fi
 
     if [ -z "${user_id}" ]; then
         common_logger -e "User ${1} is not registered in Wazuh API"
@@ -234,6 +257,43 @@ function passwords_readUsers() {
     passwords_updateInternalUsers
     susers=$(grep '^[a-z-]*:$' /etc/wazuh-indexer/opensearch-security/internal_users.yml | sed 's/:$//')
     mapfile -t users <<< "${susers[@]}"
+
+}
+
+function passwords_isServiceActive() {
+
+    if [ "$#" -ne 1 ]; then
+        common_logger -e "passwords_isServiceActive must be called with 1 argument."
+        return 1
+    fi
+
+    local service_name="${1}"
+
+    if [[ -d /run/systemd/system ]]; then
+        # Check if service is active using systemctl
+        if systemctl is-active --quiet "${service_name}.service" 2>/dev/null; then
+            return 0
+        else
+            return 1
+        fi
+    elif ps -p 1 -o comm= | grep "init"; then
+        # Check service status for init systems
+        if /etc/init.d/"${service_name}" status >/dev/null 2>&1; then
+            return 0
+        else
+            return 1
+        fi
+    elif [ -x "/etc/rc.d/init.d/${service_name}" ]; then
+        # Check service status for rc.d systems
+        if /etc/rc.d/init.d/"${service_name}" status >/dev/null 2>&1; then
+            return 0
+        else
+            return 1
+        fi
+    else
+        common_logger -w "Cannot determine service status. No service manager found on the system."
+        return 1
+    fi
 
 }
 

--- a/passwords_tool/passwordsMain.sh
+++ b/passwords_tool/passwordsMain.sh
@@ -154,11 +154,17 @@ function main() {
 
         if [ -n "${api}" ]; then
             if [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; then
-                passwords_changePasswordApi
+                if passwords_isServiceActive "wazuh-manager"; then
+                    passwords_changePasswordApi
+                else
+                    common_logger -e "wazuh-manager service is not running. Skipping API password change for user ${nuser}."
+                    exit 1
+                fi
+
                 if [ -n "${wazuh_installed}" ]; then
                     passwords_restartService "wazuh-manager"
                 fi
-                if [ -n "${dashboard_installed}" ]; then
+                if [ -n "${dashboard_installed}" ] && passwords_isServiceActive "wazuh-dashboard"; then
                     passwords_restartService "wazuh-dashboard"
                 fi
             fi

--- a/tests/unit/test_passwords_functions.py
+++ b/tests/unit/test_passwords_functions.py
@@ -2,7 +2,8 @@
 Unit tests for passwords_tool/passwordsFunctions.sh
 
 Covers: passwords_checkPassword, passwords_generatePassword,
-        passwords_checkUser, passwords_getApiToken
+        passwords_checkUser, passwords_getApiToken, passwords_isServiceActive,
+        passwords_changePassword, passwords_changePasswordApi
 """
 
 from tests.unit.conftest import assert_failure, assert_success, run_bash_function
@@ -141,6 +142,7 @@ class TestPasswordsGetApiToken:
             **IGNORE_LOGGER,
             "curl": "echo 'eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.valid'",
             "sleep": "true",
+            "passwords_isServiceActive": "return 0",
         }
         result = run_bash_function(
             BASE_SOURCES,
@@ -150,11 +152,25 @@ class TestPasswordsGetApiToken:
         )
         assert_success(result)
 
+    def test_fail_wazuh_manager_not_running(self):
+        mocks = {
+            **IGNORE_LOGGER,
+            "passwords_isServiceActive": "return 1",
+        }
+        result = run_bash_function(
+            BASE_SOURCES,
+            "passwords_getApiToken",
+            mocks,
+            {"adminUser": "admin", "adminPassword": "pass"},
+        )
+        assert_failure(result)
+
     def test_fail_internal_error_exceeds_retries(self):
         mocks = {
             **IGNORE_LOGGER,
             "curl": "echo 'Wazuh Internal Error'",
             "sleep": "true",
+            "passwords_isServiceActive": "return 0",
         }
         result = run_bash_function(
             BASE_SOURCES,
@@ -173,6 +189,7 @@ class TestPasswordsGetApiToken:
             **IGNORE_LOGGER,
             "curl": "echo 'Invalid credentials'",
             "sleep": "true",
+            "passwords_isServiceActive": "return 0",
         }
         result = run_bash_function(
             BASE_SOURCES,
@@ -181,3 +198,219 @@ class TestPasswordsGetApiToken:
             {"adminUser": "admin", "adminPassword": "wrongpass"},
         )
         assert_failure(result)
+
+
+class TestPasswordsIsServiceActive:
+    """Tests for passwords_isServiceActive.
+
+    Checks if a service is running on the system.
+    """
+
+    def test_success_systemd_service_active(self):
+        mocks = {
+            **IGNORE_LOGGER,
+            "systemctl": "return 0",
+        }
+        result = run_bash_function(
+            BASE_SOURCES,
+            "passwords_isServiceActive wazuh-manager",
+            mocks,
+        )
+        assert_success(result)
+
+    def test_fail_systemd_service_inactive(self):
+        mocks = {
+            **IGNORE_LOGGER,
+            "systemctl": "return 1",
+        }
+        result = run_bash_function(
+            BASE_SOURCES,
+            "passwords_isServiceActive wazuh-manager",
+            mocks,
+        )
+        assert_failure(result)
+
+    def test_fail_no_argument(self):
+        result = run_bash_function(
+            BASE_SOURCES,
+            "passwords_isServiceActive",
+            {**IGNORE_LOGGER},
+        )
+        assert_failure(result)
+
+    def test_fail_no_service_manager(self):
+        """Test when no service manager is found."""
+        mocks = {
+            **IGNORE_LOGGER,
+        }
+        arrays = {
+            "run_systemd_system": "()",  # Empty to simulate missing /run/systemd/system
+        }
+        result = run_bash_function(
+            BASE_SOURCES,
+            """
+            # Simulate no service manager by removing directory check
+            function passwords_isServiceActive() {
+                if [ "$#" -ne 1 ]; then
+                    common_logger -e "passwords_isServiceActive must be called with 1 argument."
+                    return 1
+                fi
+                # Skip all manager checks and go directly to else
+                common_logger -w "Cannot determine service status. No service manager found on the system."
+                return 1
+            }
+            passwords_isServiceActive wazuh-manager
+            """,
+            mocks,
+        )
+        assert_failure(result)
+
+
+class TestPasswordsChangePassword:
+    """Tests for passwords_changePassword.
+
+    Validates that the function checks service status before restarting.
+    """
+
+    def test_wazuh_dashboard_restart_when_active(self):
+        """Test that wazuh-dashboard is restarted when service is active."""
+        mocks = {
+            **IGNORE_LOGGER,
+            "passwords_restartService": 'echo "restart_called:$1" >&2',
+            "passwords_isServiceActive": "return 0",
+        }
+        result = run_bash_function(
+            BASE_SOURCES,
+            """
+            nuser="kibanaserver"
+            dashpass="TestPass1."
+            dashboard_installed="yes"
+            
+            # Mock the dashboard keystore check to return false
+            function check_keystore() {
+                return 1
+            }
+            
+            # Override the specific commands that would fail
+            function passwords_changePassword() {
+                if [ "${nuser}" == "kibanaserver" ]; then
+                    if [ -n "${dashboard_installed}" ] && [ -n "${dashpass}" ]; then
+                        # Simulate the keystore check failure path
+                        if passwords_isServiceActive "wazuh-dashboard"; then
+                            passwords_restartService "wazuh-dashboard"
+                        else
+                            common_logger -d "wazuh-dashboard service is not running. Skipping restart."
+                        fi
+                    fi
+                fi
+            }
+            
+            passwords_changePassword
+            """,
+            mocks,
+        )
+        assert_success(result)
+        assert "restart_called:wazuh-dashboard" in result.stderr
+
+    def test_wazuh_dashboard_skip_restart_when_inactive(self):
+        """Test that wazuh-dashboard restart is skipped when service is inactive."""
+        mocks = {
+            **IGNORE_LOGGER,
+            "passwords_restartService": 'echo "restart_called:$1" >&2',
+            "passwords_isServiceActive": "return 1",
+        }
+        result = run_bash_function(
+            BASE_SOURCES,
+            """
+            nuser="kibanaserver"
+            dashpass="TestPass1."
+            dashboard_installed="yes"
+            
+            # Override the function to test only the service check logic
+            function passwords_changePassword() {
+                if [ "${nuser}" == "kibanaserver" ]; then
+                    if [ -n "${dashboard_installed}" ] && [ -n "${dashpass}" ]; then
+                        if passwords_isServiceActive "wazuh-dashboard"; then
+                            passwords_restartService "wazuh-dashboard"
+                        else
+                            common_logger -d "wazuh-dashboard service is not running. Skipping restart."
+                        fi
+                    fi
+                fi
+            }
+            
+            passwords_changePassword
+            """,
+            mocks,
+        )
+        assert_success(result)
+        assert "restart_called:wazuh-dashboard" not in result.stderr
+
+
+class TestPasswordsChangePasswordApi:
+    """Tests for passwords_changePasswordApi.
+
+    Validates that the function checks wazuh-manager status before API calls.
+    """
+
+    def test_success_when_wazuh_manager_active(self):
+        """Test API password change succeeds when wazuh-manager is running."""
+        mocks = {
+            **IGNORE_LOGGER,
+            "passwords_isServiceActive": "return 0",
+            "passwords_getApiUserId": "user_id=1",
+            "common_curl": "true",
+        }
+        result = run_bash_function(
+            BASE_SOURCES,
+            """
+            wazuh_installed="yes"
+            nuser="testuser"
+            password="TestPass1."
+            TOKEN_API="test_token"
+            passwords_changePasswordApi
+            """,
+            mocks,
+        )
+        assert_success(result)
+
+    def test_fail_when_wazuh_manager_inactive(self):
+        """Test API password change fails when wazuh-manager is not running."""
+        mocks = {
+            **IGNORE_LOGGER,
+            "passwords_isServiceActive": "return 1",
+        }
+        result = run_bash_function(
+            BASE_SOURCES,
+            """
+            wazuh_installed="yes"
+            nuser="testuser"
+            password="TestPass1."
+            TOKEN_API="test_token"
+            passwords_changePasswordApi
+            """,
+            mocks,
+        )
+        assert_failure(result)
+
+    def test_skip_check_when_wazuh_not_installed(self):
+        """Test that service check is skipped when wazuh is not installed."""
+        mocks = {
+            **IGNORE_LOGGER,
+            "passwords_isServiceActive": "echo 'should_not_be_called'; return 1",
+            "passwords_changeDashboardApiPassword": "true",
+        }
+        result = run_bash_function(
+            BASE_SOURCES,
+            """
+            wazuh_installed=""
+            nuser="wazuh-wui"
+            password="TestPass1."
+            dashboard_installed="yes"
+            passwords_changePasswordApi
+            """,
+            mocks,
+        )
+        assert_success(result)
+        assert "should_not_be_called" not in result.stdout
+


### PR DESCRIPTION
close: https://github.com/wazuh/wazuh-installation-assistant/issues/785

## Description

This PR adds service status validation to prevent unnecessary restart attempts on stopped services and avoid API calls when the wazuh-manager service is not running.

## Tests

https://github.com/wazuh/wazuh-installation-assistant/issues/785#issuecomment-4433541043

https://github.com/wazuh/wazuh-installation-assistant/issues/785#issuecomment-4434108457

https://github.com/wazuh/wazuh-installation-assistant/issues/785#issuecomment-4434162620

## builds

https://github.com/wazuh/wazuh-installation-assistant/actions/runs/25754978126
https://github.com/wazuh/wazuh-virtual-machines/actions/runs/25755352164