### PR TITLE
Removed simple quote from manager.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Removed simple quote from manager.sh. ([#800](https://github.com/wazuh/wazuh-installation-assistant/pull/800))
 - Fixed step-by-step installation documentation errors ([#781](https://github.com/wazuh/wazuh-installation-assistant/pull/781))
 - Fix install dependencies logic and delete redundant functions ([#748](https://github.com/wazuh/wazuh-installation-assistant/pull/748))
 - The security of the installation assistant is improved when creating configuration files in main. ([#737](https://github.com/wazuh/wazuh-installation-assistant/pull/737))

--- a/install_functions/manager.sh
+++ b/install_functions/manager.sh
@@ -38,7 +38,7 @@ function manager_startCluster() {
         -e "${lstart},${lend}s/<node>.*<\/node>/<node>${master_address}<\/node>/" \
         -e "${lstart},${lend}s/<hidden>.*<\/hidden>/<hidden>${hidden}<\/hidden>/" \
         -e "${lstart},${lend}s/<disabled>.*<\/disabled>/<disabled>${disabled}<\/disabled>/" \
-        /var/wazuh-manager/etc/wazuh-manager.conf'
+        /var/wazuh-manager/etc/wazuh-manager.conf
 
 }
 


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-installation-assistant/issues/799


```console
vagrant@cbordon-5644:~$ sudo bash wazuh-install.sh -a -id -d local
15/05/2026 12:17:11 INFO: Starting Wazuh installation assistant. Wazuh version: 5.0.0
15/05/2026 12:17:11 INFO: Verbose logging redirected to /var/log/wazuh-install.log
15/05/2026 12:17:26 INFO: --- Dependencies ----
15/05/2026 12:17:26 INFO: Installing apt-transport-https.
15/05/2026 12:17:30 INFO: Installing debhelper.
15/05/2026 12:17:45 INFO: Verifying that your system meets the recommended minimum hardware requirements.
15/05/2026 12:17:46 INFO: --- Configuration files ---
15/05/2026 12:17:46 INFO: Generating configuration files.
15/05/2026 12:17:48 INFO: Generating the root certificate.
15/05/2026 12:17:48 INFO: Generating Admin certificates.
15/05/2026 12:17:48 INFO: Generating Wazuh indexer certificates.
15/05/2026 12:17:48 INFO: Generating Wazuh manager certificates.
15/05/2026 12:17:48 INFO: Generating Wazuh dashboard certificates.
15/05/2026 12:17:48 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key and the certificates necessary for installation.
15/05/2026 12:17:49 INFO: --- Wazuh indexer ---
15/05/2026 12:17:49 INFO: Downloading wazuh_indexer package: wazuh-indexer_5.0.0-latest_amd64.deb
15/05/2026 12:19:51 INFO: wazuh_indexer package downloaded successfully: /home/vagrant/wazuh-install-packages/wazuh-indexer_5.0.0-latest_amd64.deb
15/05/2026 12:19:51 INFO: Starting Wazuh indexer installation.
15/05/2026 12:20:13 INFO: Wazuh indexer installation finished.
15/05/2026 12:20:14 INFO: Wazuh indexer post-install configuration finished.
15/05/2026 12:20:14 INFO: Starting service wazuh-indexer.
15/05/2026 12:20:32 INFO: wazuh-indexer service started.
15/05/2026 12:20:52 INFO: Wazuh indexer cluster security configuration initialized.
15/05/2026 12:20:52 INFO: --- Wazuh manager ---
15/05/2026 12:20:52 INFO: Downloading wazuh_manager package: wazuh-manager_5.0.0-latest_amd64.deb
15/05/2026 12:21:14 INFO: wazuh_manager package downloaded successfully: /home/vagrant/wazuh-install-packages/wazuh-manager_5.0.0-latest_amd64.deb
15/05/2026 12:21:14 INFO: Starting the Wazuh manager installation.
15/05/2026 12:22:10 INFO: Wazuh manager installation finished.
15/05/2026 12:22:10 INFO: Starting service wazuh-manager.
15/05/2026 12:22:25 INFO: wazuh-manager service started.
15/05/2026 12:22:25 INFO: --- Wazuh dashboard ---
15/05/2026 12:22:25 INFO: Downloading wazuh_dashboard package: wazuh-dashboard_5.0.0-latest_amd64.deb
15/05/2026 12:22:57 INFO: wazuh_dashboard package downloaded successfully: /home/vagrant/wazuh-install-packages/wazuh-dashboard_5.0.0-latest_amd64.deb
15/05/2026 12:22:57 INFO: Starting Wazuh dashboard installation.
15/05/2026 12:24:44 INFO: Wazuh dashboard installation finished.
15/05/2026 12:24:44 INFO: Wazuh dashboard post-install configuration finished.
15/05/2026 12:24:44 INFO: Starting service wazuh-dashboard.
15/05/2026 12:24:45 INFO: wazuh-dashboard service started.
15/05/2026 12:24:45 INFO: Wazuh dashboard web application initialized.
15/05/2026 12:24:45 INFO: --- Summary ---
15/05/2026 12:24:45 INFO: You can access the web interface https://<wazuh_dashboard_ip>:443
    User: admin
    Password: admin
15/05/2026 12:24:45 INFO: Installation finished.
```

```console
vagrant@cbordon-5644:~$ sudo bash wazuh-passwords-tool.sh -u admin -p TestingPassword1?
15/05/2026 12:27:49 INFO: Updating the internal users.
15/05/2026 12:27:59 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
15/05/2026 12:27:59 INFO: Generating password hash
15/05/2026 12:28:32 WARNING: Password changed. Remember to update the password in the Wazuh dashboard and the Wazuh manager nodes if necessary, and restart the services.
```