### PR TITLE
Updated test instances size

### DIFF
--- a/.github/workflows/check_integration_tools.yaml
+++ b/.github/workflows/check_integration_tools.yaml
@@ -345,7 +345,7 @@ jobs:
           python3 wazuh-automation/deployability/modules/allocation/main.py \
             --action create \
             --provider aws \
-            --size large \
+            --size xlarge \
             --composite-name ${{ matrix.system }} \
             --working-dir ${{ env.ALLOCATOR_PATH }} \
             --track-output ${{ env.ALLOCATOR_PATH }}/track.yml \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Updated test instances size. ([#804](https://github.com/wazuh/wazuh-installation-assistant/pull/804))
 - VD log message removed ([#795](https://github.com/wazuh/wazuh-installation-assistant/pull/795))
 - Fixed clusterized documentation for wazuh-install.sh download file. ([#794](https://github.com/wazuh/wazuh-installation-assistant/pull/794))
 - Updated step by step documentation with apt and yum commands. ([#779](https://github.com/wazuh/wazuh-installation-assistant/pull/779))


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-installation-assistant/issues/793

## Description

The size of the test instances for integration tests has been updated to avoid these errors:

```console
13:14:21 [heartbeat] AIO installation in progress...
18/05/2026 13:14:21 INFO: Starting Wazuh installation assistant. Wazuh version: 5.0.0
18/05/2026 13:14:21 INFO: Verbose logging redirected to /var/log/wazuh-install.log
18/05/2026 13:14:22 INFO: Verifying that your system meets the recommended minimum hardware requirements.
18/05/2026 13:14:22 ERROR: Your system does not meet the recommended minimum hardware requirements of 16Gb of RAM and 8 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements.
--- Last 50 lines of install log ---
18/05/2026 13:14:21 INFO: Starting Wazuh installation assistant. Wazuh version: 5.0.0
18/05/2026 13:14:21 INFO: Verbose logging redirected to /var/log/wazuh-install.log
18/05/2026 13:14:22 INFO: Verifying that your system meets the recommended minimum hardware requirements.
18/05/2026 13:14:22 ERROR: Your system does not meet the recommended minimum hardware requirements of 16Gb of RAM and 8 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements.

```