### PR TITLE
Add open and reopened types for pull requests trigger in check_unit_tests workflow

### DIFF
--- a/.github/workflows/check_unit_tests.yaml
+++ b/.github/workflows/check_unit_tests.yaml
@@ -3,7 +3,7 @@ name: PR Check - Unit Tests
 
 on:
   pull_request:
-    types: [ready_for_review, synchronize]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add open and reopened types for pull requests trigger in check_unit_tests workflow ([#805](https://github.com/wazuh/wazuh-installation-assistant/pull/805))
 - A validation for the status of services is added to the password tool. ([#786](https://github.com/wazuh/wazuh-installation-assistant/pull/786))
 - Added support for pre-release installation in documentation ([#784](https://github.com/wazuh/wazuh-installation-assistant/pull/784))
 - Added repository download documentation ([#783](https://github.com/wazuh/wazuh-installation-assistant/pull/783))


### PR DESCRIPTION
## Description

The “opened” and “reopened” statuses have been added to the pull request trigger types in the unit test check workflow.