### PR TITLE
Force Filebeat revision to be `-1` when installed by repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Force Filebeat revision to be -1 when installed by repository ([#807](https://github.com/wazuh/wazuh-installation-assistant/pull/807))
 - Updated the password tool with hash script modifications. ([#801](https://github.com/wazuh/wazuh-installation-assistant/pull/801))
 - The security of the installation assistant is improved when creating configuration files in LTS version. ([#723](https://github.com/wazuh/wazuh-installation-assistant/pull/723))
 

--- a/install_functions/filebeat.sh
+++ b/install_functions/filebeat.sh
@@ -101,9 +101,9 @@ function filebeat_install() {
 
     common_logger "Starting Filebeat installation."
     if [ "${sys_type}" == "yum" ]; then
-        installCommon_yumInstall "filebeat" "${filebeat_version}"
+        installCommon_yumInstall "filebeat" "${filebeat_version}-1"
     elif [ "${sys_type}" == "apt-get" ]; then
-        installCommon_aptInstall "filebeat" "${filebeat_version}"
+        installCommon_aptInstall "filebeat" "${filebeat_version}-1"
     fi
 
     install_result="${PIPESTATUS[0]}"


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-installation-assistant/issues/806

# Description

The aim of this PR is to fix the Filebeat revision package downloaded by forcing it to have the revision `-1` for the LTS (`4.10`) version.

## Test

<details>
<summary>AIO installation:</summary>

```
root@ubuntu-jammy:/home/vagrant# bash wazuh-install.sh -a -d pre-release -v
19/05/2026 14:44:13 DEBUG: Checking root permissions.
19/05/2026 14:44:13 DEBUG: Checking sudo package.
19/05/2026 14:44:13 INFO: Starting Wazuh installation assistant. Wazuh version: 4.10.4
19/05/2026 14:44:13 INFO: Verbose logging redirected to /var/log/wazuh-install.log
19/05/2026 14:44:13 DEBUG: APT package manager will be used.
19/05/2026 14:44:13 DEBUG: Checking system distribution.
19/05/2026 14:44:13 DEBUG: Detected distribution name: ubuntu
19/05/2026 14:44:13 DEBUG: Detected distribution version: 22
19/05/2026 14:44:13 DEBUG: Installing check dependencies.
Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists...
19/05/2026 14:44:16 DEBUG: Checking Wazuh installation.
19/05/2026 14:44:18 DEBUG: Checking system architecture.
19/05/2026 14:44:18 INFO: Verifying that your system meets the recommended minimum hardware requirements.
19/05/2026 14:44:18 DEBUG: CPU cores detected: 2
19/05/2026 14:44:18 DEBUG: Free RAM memory detected: 3911
19/05/2026 14:44:18 INFO: Wazuh web interface port will be 443.
19/05/2026 14:44:18 DEBUG: Checking ports availability.
Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists...
19/05/2026 14:44:20 DEBUG: Installing prerequisites dependencies.
19/05/2026 14:44:22 INFO: --- Dependencies ----
19/05/2026 14:44:22 INFO: Installing apt-transport-https.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: apt-transport-https 0 upgraded, 1 newly installed, 0 to remove and 62 not upgraded. Need to get 1510 B of archives. After this operation, 170 kB of additional disk space will be used. Get:1 http://archive.ubuntu.com/ubuntu jammy-updates Running kernel seems to be up-to-date. No services need to be restarted. No containers need to be restarted. No user sessions are running outdated binaries. No VM guests are running outdated hypervisor (qemu) binaries on this host.
19/05/2026 14:44:25 INFO: Installing debhelper.
Reading package lists... Building dependency tree... Reading state information... The following additional packages will be installed: autoconf automake autopoint autotools-dev debugedit dh-autoreconf dh-strip-nondeterminism dwz gettext intltool-debian libarchive-cpio-perl libarchive-zip-perl libdebhelper-perl libfile-stripnondeterminism-perl libltdl-dev libltdl7 libmail-sendmail-perl libsub-override-perl libsys-hostname-long-perl libtool m4 po-debconf Suggested packages: autoconf-archive gnu-standards autoconf-doc dh-make gettext-doc libasprintf-dev libgettextpo-dev libtool-doc gfortran | fortran95-compiler gcj-jdk m4-doc libmail-box-perl The following NEW packages will be installed: autoconf automake autopoint autotools-dev debhelper debugedit dh-autoreconf dh-strip-nondeterminism dwz gettext intltool-debian libarchive-cpio-perl libarchive-zip-perl libdebhelper-perl libfile-stripnondeterminism-perl libltdl-dev libltdl7 libmail-sendmail-perl libsub-override-perl libsys-hostname-long-perl libtool m4 po-debconf 0 upgraded, 23 newly installed, 0 to remove and 62 not upgraded. Need to get 4385 kB of archives. After this operation, 13.5 MB of additional disk space will be used. Get:1 http://archive.ubuntu.com/ubuntu jammy/main amd64 m4 amd64 1.4.18-5ubuntu2 [199 kB] Get:2 http://archive.ubuntu.com/ubuntu jammy/main amd64 autoconf all 2.71-2 [338 kB] Get:3 http://archive.ubuntu.com/ubuntu jammy/main amd64 autotools-dev all 20220109.1 [44.9 kB] Get:4 http://archive.ubuntu.com/ubuntu jammy/main amd64 automake all 1:1.16.5-1.3 [558 kB] Get:5 http://archive.ubuntu.com/ubuntu jammy/main amd64 autopoint all 0.21-4ubuntu4 [422 kB] Get:6 http://archive.ubuntu.com/ubuntu jammy/main amd64 libdebhelper-perl all 13.6ubuntu1 [67.2 kB] Get:7 http://archive.ubuntu.com/ubuntu jammy/main amd64 libtool all 2.4.6-15build2 [164 kB] Get:8 http://archive.ubuntu.com/ubuntu jammy/main amd64 dh-autoreconf all 20 [16.1 kB] Get:9 http://archive.ubuntu.com/ubuntu jammy/main amd64 libarchive-zip-perl all 1.68-1 [90.2 kB] Get:10 http://archive.ubuntu.com/ubuntu jammy/main amd64 libsub-override-perl all 0.09-2 [9532 B] Get:11 http://archive.ubuntu.com/ubuntu jammy/main amd64 libfile-stripnondeterminism-perl all 1.13.0-1 [18.1 kB] Get:12 http://archive.ubuntu.com/ubuntu jammy/main amd64 dh-strip-nondeterminism all 1.13.0-1 [5344 B] Get:13 http://archive.ubuntu.com/ubuntu jammy/main amd64 debugedit amd64 1:5.0-4build1 [47.2 kB] Get:14 http://archive.ubuntu.com/ubuntu jammy/main amd64 dwz amd64 0.14-1build2 [105 kB] Get:15 http://archive.ubuntu.com/ubuntu jammy/main amd64 gettext amd64 0.21-4ubuntu4 [868 kB] Get:16 http://archive.ubuntu.com/ubuntu jammy/main amd64 intltool-debian all 0.35.0+20060710.5 [24.9 kB] Get:17 http://archive.ubuntu.com/ubuntu jammy/main amd64 po-debconf all 1.0.21+nmu1 [233 kB] Get:18 http://archive.ubuntu.com/ubuntu jammy/main amd64 debhelper all 13.6ubuntu1 [923 kB] Get:19 http://archive.ubuntu.com/ubuntu jammy/main amd64 libarchive-cpio-perl all 0.10-1.1 [9928 B] Get:20 http://archive.ubuntu.com/ubuntu jammy/main amd64 libltdl7 amd64 2.4.6-15build2 [39.6 kB] Get:21 http://archive.ubuntu.com/ubuntu jammy/main amd64 libltdl-dev amd64 2.4.6-15build2 [169 kB] Get:22 http://archive.ubuntu.com/ubuntu jammy/main amd64 libsys-hostname-long-perl all 1.5-2 [11.5 kB] Get:23 http://archive.ubuntu.com/ubuntu jammy/main amd64 libmail-sendmail-perl all 0.80-1.1 [22.7 kB] Fetched 4385 kB in 0s (17.6 MB/s) Selecting previo Running kernel seems to be up-to-date. No services need to be restarted. No containers need to be restarted. No user sessions are running outdated binaries. No VM guests are running outdated hypervisor (qemu) binaries on this host.
19/05/2026 14:44:28 DEBUG: Checking curl tool version.
19/05/2026 14:44:28 DEBUG: Adding the Wazuh repository.
gpg: keyring '/usr/share/keyrings/wazuh.gpg' created
gpg: directory '/root/.gnupg' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 96B3EE5F29111145: public key "Wazuh.com (Wazuh Signing Key) <support@wazuh.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main
Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable InRelease [17.3 kB]
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Get:5 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 Packages [52.7 kB]
Hit:6 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Fetched 70.0 kB in 0s (205 kB/s)
Reading package lists...
19/05/2026 14:44:29 INFO: Wazuh development repository added.
19/05/2026 14:44:29 INFO: --- Configuration files ---
19/05/2026 14:44:29 INFO: Generating configuration files.
19/05/2026 14:44:30 DEBUG: Creating Wazuh certificates.
19/05/2026 14:44:30 DEBUG: Reading configuration file.
19/05/2026 14:44:30 DEBUG: Checking if 127.0.0.1 is private.
19/05/2026 14:44:30 DEBUG: Checking if 127.0.0.1 is private.
19/05/2026 14:44:30 DEBUG: Checking if 127.0.0.1 is private.
19/05/2026 14:44:30 INFO: Generating the root certificate.
19/05/2026 14:44:30 INFO: Generating Admin certificates.
19/05/2026 14:44:30 DEBUG: Generating Admin private key.
19/05/2026 14:44:30 DEBUG: Converting Admin private key to PKCS8 format.
19/05/2026 14:44:30 DEBUG: Generating Admin CSR.
19/05/2026 14:44:30 DEBUG: Creating Admin certificate.
19/05/2026 14:44:30 INFO: Generating Wazuh indexer certificates.
19/05/2026 14:44:30 DEBUG: Creating the certificates for wazuh-indexer indexer node.
19/05/2026 14:44:30 DEBUG: Generating certificate configuration.
19/05/2026 14:44:30 DEBUG: Creating the Wazuh indexer tmp key pair.
19/05/2026 14:44:30 DEBUG: Creating the Wazuh indexer certificates.
19/05/2026 14:44:30 INFO: Generating Filebeat certificates.
19/05/2026 14:44:30 DEBUG: Generating the certificates for wazuh-server server node.
19/05/2026 14:44:30 DEBUG: Generating certificate configuration.
19/05/2026 14:44:30 DEBUG: Creating the Wazuh server tmp key pair.
19/05/2026 14:44:30 DEBUG: Creating the Wazuh server certificates.
19/05/2026 14:44:30 INFO: Generating Wazuh dashboard certificates.
19/05/2026 14:44:30 DEBUG: Generating certificate configuration.
19/05/2026 14:44:30 DEBUG: Creating the Wazuh dashboard tmp key pair.
19/05/2026 14:44:30 DEBUG: Creating the Wazuh dashboard certificates.
19/05/2026 14:44:30 DEBUG: Cleaning certificate files.
19/05/2026 14:44:31 DEBUG: Generating password file.
19/05/2026 14:44:31 DEBUG: Generating random passwords.
19/05/2026 14:44:31 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
19/05/2026 14:44:31 DEBUG: Extracting Wazuh configuration.
19/05/2026 14:44:31 DEBUG: Reading configuration file.
19/05/2026 14:44:31 DEBUG: Checking if 127.0.0.1 is private.
19/05/2026 14:44:31 DEBUG: Checking if 127.0.0.1 is private.
19/05/2026 14:44:31 DEBUG: Checking if 127.0.0.1 is private.
19/05/2026 14:44:31 INFO: --- Wazuh indexer ---
19/05/2026 14:44:31 INFO: Starting Wazuh indexer installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-indexer 0 upgraded, 1 newly installed, 0 to remove and 62 not upgraded. Need to get 892 MB of archives. After this operation, 1126 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt unst Running kernel seems to be up-to-date. No services need to be restarted. No containers need to be restarted. No user sessions are running outdated binaries. No VM guests are running outdated hypervisor (qemu) binaries on this host.
19/05/2026 14:45:30 DEBUG: Checking Wazuh installation.
19/05/2026 14:45:31 DEBUG: There are Wazuh indexer remaining files.
19/05/2026 14:45:31 INFO: Wazuh indexer installation finished.
19/05/2026 14:45:31 DEBUG: Configuring Wazuh indexer.
19/05/2026 14:45:31 DEBUG: Copying Wazuh indexer certificates.
19/05/2026 14:45:31 INFO: Wazuh indexer post-install configuration finished.
19/05/2026 14:45:31 INFO: Starting service wazuh-indexer.
Synchronizing state of wazuh-indexer.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable wazuh-indexer
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.
19/05/2026 14:45:40 INFO: wazuh-indexer service started.
19/05/2026 14:45:40 INFO: Initializing Wazuh indexer cluster security settings.
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.19.5
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","actiongroups","config","internalusers"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","actiongroups","config","internalusers"]) due to: null
Done with success
19/05/2026 14:45:44 INFO: Wazuh indexer cluster security configuration initialized.
19/05/2026 14:45:44 INFO: Wazuh indexer cluster initialized.
19/05/2026 14:45:44 INFO: --- Wazuh server ---
19/05/2026 14:45:44 INFO: Starting the Wazuh manager installation.
Reading package lists... Building dependency tree... Reading state information... Suggested packages: expect The following NEW packages will be installed: wazuh-manager 0 upgraded, 1 newly installed, 0 to remove and 63 not upgraded. Need to get 504 MB of archives. After this operation, 1083 MB of additional disk space will be used. Get:1 https://packages-dev.waz Running kernel seems to be up-to-date. Services to be restarted: systemctl restart wazuh-indexer.service No containers need to be restarted. No user sessions are running outdated binaries. No VM guests are running outdated hypervisor (qemu) binaries on this host.
19/05/2026 14:46:30 DEBUG: Checking Wazuh installation.
19/05/2026 14:46:30 DEBUG: There are Wazuh remaining files.
19/05/2026 14:46:30 DEBUG: There are Wazuh indexer remaining files.
19/05/2026 14:46:31 INFO: Wazuh manager installation finished.
19/05/2026 14:46:31 DEBUG: Configuring Wazuh manager.
19/05/2026 14:46:31 DEBUG: Setting provisional Wazuh indexer password.
19/05/2026 14:46:31 INFO: Wazuh manager vulnerability detection configuration finished.
19/05/2026 14:46:31 INFO: Starting service wazuh-manager.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.
19/05/2026 14:46:46 INFO: wazuh-manager service started.
19/05/2026 14:46:46 INFO: Starting Filebeat installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: filebeat 0 upgraded, 1 newly installed, 0 to remove and 64 not upgraded. Need to get 22.1 MB of archives. After this operation, 73.6 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable Running kernel seems to be up-to-date. Services to be restarted: systemctl restart wazuh-indexer.service No containers need to be restarted. No user sessions are running outdated binaries. No VM guests are running outdated hypervisor (qemu) binaries on this host.
19/05/2026 14:46:55 DEBUG: Checking Wazuh installation.
19/05/2026 14:46:55 DEBUG: There are Wazuh remaining files.
19/05/2026 14:46:56 DEBUG: There are Wazuh indexer remaining files.
19/05/2026 14:46:56 DEBUG: There are Filebeat remaining files.
19/05/2026 14:46:56 INFO: Filebeat installation finished.
19/05/2026 14:46:56 DEBUG: Configuring Filebeat.
19/05/2026 14:46:56 DEBUG: Filebeat template was download successfully.
wazuh/
wazuh/alerts/
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/alerts/manifest.yml
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/_meta/
wazuh/_meta/docs.asciidoc
wazuh/_meta/config.yml
wazuh/_meta/fields.yml
wazuh/module.yml
wazuh/archives/
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/archives/manifest.yml
wazuh/archives/config/
wazuh/archives/config/archives.yml
19/05/2026 14:46:57 DEBUG: Filebeat module was downloaded successfully.
19/05/2026 14:46:57 DEBUG: Copying Filebeat certificates.
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
19/05/2026 14:46:57 INFO: Filebeat post-install configuration finished.
19/05/2026 14:46:57 INFO: Starting service filebeat.
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.
19/05/2026 14:46:58 INFO: filebeat service started.
19/05/2026 14:46:58 INFO: --- Wazuh dashboard ---
19/05/2026 14:46:58 INFO: Starting Wazuh dashboard installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-dashboard 0 upgraded, 1 newly installed, 0 to remove and 65 not upgraded. Need to get 183 MB of archives. After this operation, 994 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt uns Running kernel seems to be up-to-date. Services to be restarted: systemctl restart wazuh-indexer.service No containers need to be restarted. No user sessions are running outdated binaries. No VM guests are running outdated hypervisor (qemu) binaries on this host.
19/05/2026 14:49:24 DEBUG: Checking Wazuh installation.
19/05/2026 14:49:24 DEBUG: There are Wazuh remaining files.
19/05/2026 14:49:24 DEBUG: There are Wazuh indexer remaining files.
19/05/2026 14:49:25 DEBUG: There are Filebeat remaining files.
19/05/2026 14:49:25 DEBUG: There are Wazuh dashboard remaining files.
19/05/2026 14:49:25 INFO: Wazuh dashboard installation finished.
19/05/2026 14:49:25 DEBUG: Configuring Wazuh dashboard.
19/05/2026 14:49:25 DEBUG: Copying Wazuh dashboard certificates.
19/05/2026 14:49:25 DEBUG: Wazuh dashboard certificate setup finished.
19/05/2026 14:49:25 INFO: Wazuh dashboard post-install configuration finished.
19/05/2026 14:49:25 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
19/05/2026 14:49:25 INFO: wazuh-dashboard service started.
19/05/2026 14:49:25 DEBUG: Setting Wazuh indexer cluster passwords.
19/05/2026 14:49:25 DEBUG: Checking Wazuh installation.
19/05/2026 14:49:26 DEBUG: There are Wazuh remaining files.
19/05/2026 14:49:26 DEBUG: There are Wazuh indexer remaining files.
19/05/2026 14:49:26 DEBUG: There are Filebeat remaining files.
19/05/2026 14:49:27 DEBUG: There are Wazuh dashboard remaining files.
19/05/2026 14:49:27 INFO: Updating the internal users.
19/05/2026 14:49:27 DEBUG: Creating password backup.
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.19.5
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
19/05/2026 14:49:30 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
19/05/2026 14:49:30 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
19/05/2026 14:49:30 DEBUG: The internal users have been updated before changing the passwords.
19/05/2026 14:49:31 DEBUG: Generating password hashes.
19/05/2026 14:49:36 DEBUG: Password hashes generated.
19/05/2026 14:49:36 DEBUG: Creating password backup.
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.19.5
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
19/05/2026 14:49:38 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
Successfully updated the keystore
Successfully updated the keystore
19/05/2026 14:49:38 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
19/05/2026 14:49:38 DEBUG: Restarting filebeat service...
19/05/2026 14:49:38 DEBUG: filebeat started.
19/05/2026 14:49:38 DEBUG: Restarting wazuh-manager service...
19/05/2026 14:49:57 DEBUG: wazuh-manager started.
19/05/2026 14:49:58 DEBUG: Restarting wazuh-dashboard service...
19/05/2026 14:49:58 DEBUG: wazuh-dashboard started.
19/05/2026 14:49:58 DEBUG: Running security admin tool.
19/05/2026 14:49:58 DEBUG: Loading new passwords changes.
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.19.5
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /home/vagrant
Force type: internalusers
Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
Done with success
19/05/2026 14:50:01 DEBUG: Passwords changed.
19/05/2026 14:50:01 DEBUG: Changing API passwords.
19/05/2026 14:50:07 INFO: Initializing Wazuh dashboard web application.
19/05/2026 14:50:09 INFO: Wazuh dashboard web application initialized.
19/05/2026 14:50:09 INFO: --- Summary ---
19/05/2026 14:50:09 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: OcsmBc58QkW.Ap27hlQ?acyWKvJRCQRm
19/05/2026 14:50:09 DEBUG: Restoring Wazuh repository.
19/05/2026 14:50:09 INFO: Installation finished.
```

</details>



Packages installed:

```shellsession
root@ubuntu-jammy:/home/vagrant# grep " install " /var/log/dpkg.log | tail -n 4
2026-05-19 14:45:18 install wazuh-indexer:amd64 <none> 4.10.4-1
2026-05-19 14:45:50 install wazuh-manager:amd64 <none> 4.10.4-1
2026-05-19 14:46:50 install filebeat:amd64 <none> 7.10.2-1
2026-05-19 14:47:02 install wazuh-dashboard:amd64 <none> 4.10.4-1
root@ubuntu-jammy:/home/vagrant# dpkg -l filebeat
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version      Architecture Description
+++-==============-============-============-==================================================================
ii  filebeat       7.10.2-1     amd64        Filebeat sends log files to Logstash or directly to Elasticsearch.
```