### PR TITLE
Removed support for `-i` option in the Installation Assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ All notable changes to this project will be documented in this file.
 
 ### Deleted
 
+- Removed support for -i option in the Installation Assistant ([#817](https://github.com/wazuh/wazuh-installation-assistant/pull/817))
 - Removed old Wazuh installation assistant test workflows. ([#803](https://github.com/wazuh/wazuh-installation-assistant/pull/803))
 - Deleted yum-utils and lsof dependencies ([#692](https://github.com/wazuh/wazuh-installation-assistant/pull/692))
 - Remove last_stage and other deprecated variables and functions in the installation Assistant ([#593](https://github.com/wazuh/wazuh-installation-assistant/pull/593))

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ All the options for the Wazuh installation assistant are listed in the following
 | `-dw`, `--download-wazuh <deb,rpm>`   | Download all the packages necessary for offline installation. Specify the type of packages to download for offline installation (`rpm`, `deb`).  |
 | `-g`, `--generate-config-files`       | Generate `wazuh-install-files.tar` file containing the files needed for installation from `config.yml`. In distributed deployments, you will need to copy this file to all hosts.  |
 | `-h`, `--help`                        | Display this help and exit.  |
-| `-i`, `--ignore-check`                | Ignore the check for minimum hardware requirements.  |
 | `-o`, `--overwrite`                   | Overwrite previously installed components. This will erase all the existing configuration and data.  |
 | `-of`, `--offline-installation`       | Perform an offline installation. This option must be used with `-a`, `-wm`, `-s`, `-wi`, or `-wd`.  |
 | `-s`, `--start-cluster`               | Initialize Wazuh indexer cluster security settings.  |

--- a/docs/ref/configuration/command-line-options.md
+++ b/docs/ref/configuration/command-line-options.md
@@ -14,7 +14,6 @@ The Wazuh Installation Assistant is used by running the previously downloaded `w
 | `-da`, `--download-arch <amd64\|arm64\|x86_64\|aarch64>` | Define the architecture of the packages to download for offline installation. |
 | `-g`, `--generate-config-files` | Generate wazuh-install-files.tar file containing the files that will be needed for installation from config.yml. In distributed deployments you will need to copy this file to all hosts. |
 | `-h`, `--help` | Display this help and exit. |
-| `-i`, `--ignore-check` | Ignore the check for minimum hardware requirements. |
 | `-id`, `--install-dependencies` | Installs automatically the necessary dependencies for the installation. |
 | `-o`, `--overwrite` | Overwrites previously installed components. This will erase all the existing configuration and data. |
 | `-of`, `--offline-installation` | Perform an offline installation. This option must be used with -a, -ws, -s, -wi, or -wd. |

--- a/docs/ref/getting-started/usage.md
+++ b/docs/ref/getting-started/usage.md
@@ -14,7 +14,6 @@ The Wazuh Installation Assistant is used by running the previously downloaded `w
 | `-da`, `--download-arch <amd64\|arm64\|x86_64\|aarch64>` | Define the architecture of the packages to download for offline installation. |
 | `-g`, `--generate-config-files` | Generate wazuh-install-files.tar file containing the files that will be needed for installation from config.yml. In distributed deployments you will need to copy this file to all hosts. |
 | `-h`, `--help` | Display this help and exit. |
-| `-i`, `--ignore-check` | Ignore the check for minimum hardware requirements. |
 | `-id`, `--install-dependencies` | Installs automatically the necessary dependencies for the installation. |
 | `-o`, `--overwrite` | Overwrites previously installed components. This will erase all the existing configuration and data. |
 | `-of`, `--offline-installation` | Perform an offline installation. This option must be used with -a, -ws, -s, -wi, or -wd. |

--- a/install_functions/checks.sh
+++ b/install_functions/checks.sh
@@ -265,29 +265,25 @@ function checks_health() {
 
     if [ -n "${indexer}" ]; then
         if [ "${cores}" -lt 4 ] || [ "${ram_gb}" -lt 7300 ]; then
-            common_logger -e "Your system does not meet the recommended minimum hardware requirements of 8Gb of RAM and 4 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
-            exit 1
+            common_logger -w "Your system does not meet the recommended minimum hardware requirements of 8Gb of RAM and 4 CPU cores. The installation will continue, but it may not work properly."
         fi
     fi
 
     if [ -n "${dashboard}" ]; then
         if [ "${cores}" -lt 2 ] || [ "${ram_gb}" -lt 3300 ]; then
-            common_logger -e "Your system does not meet the recommended minimum hardware requirements of 4Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
-            exit 1
+            common_logger -w "Your system does not meet the recommended minimum hardware requirements of 4Gb of RAM and 2 CPU cores. The installation will continue, but it may not work properly."
         fi
     fi
 
     if [ -n "${wazuh}" ]; then
         if [ "${cores}" -lt 4 ] || [ "${ram_gb}" -lt 7300 ]; then
-            common_logger -e "Your system does not meet the recommended minimum hardware requirements of 8Gb of RAM and 4 CPU cores . If you want to proceed with the installation use the -i option to ignore these requirements."
-            exit 1
+            common_logger -w "Your system does not meet the recommended minimum hardware requirements of 8Gb of RAM and 4 CPU cores. The installation will continue, but it may not work properly."
         fi
     fi
 
     if [ -n "${AIO}" ]; then
         if [ "${cores}" -lt 8 ] || [ "${ram_gb}" -lt 15300 ]; then
-            common_logger -e "Your system does not meet the recommended minimum hardware requirements of 16Gb of RAM and 8 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
-            exit 1
+            common_logger -w "Your system does not meet the recommended minimum hardware requirements of 16Gb of RAM and 8 CPU cores. The installation will continue, but it may not work properly."
         fi
     fi
 

--- a/install_functions/installMain.sh
+++ b/install_functions/installMain.sh
@@ -34,9 +34,6 @@ function getHelp() {
     echo -e "        -h,  --help"
     echo -e "                Display this help and exit."
     echo -e ""
-    echo -e "        -i,  --ignore-check"
-    echo -e "                Ignore the check for minimum hardware requirements."
-    echo -e ""
     echo -e "        -id,  --install-dependencies"
     echo -e "                Installs automatically the necessary dependencies for the installation."
     echo -e ""
@@ -103,10 +100,6 @@ function main() {
                 ;;
             "-h"|"--help")
                 getHelp
-                ;;
-            "-i"|"--ignore-check")
-                ignore=1
-                shift 1
                 ;;
             "-id"|"--install-dependencies")
                 install_dependencies=1
@@ -231,12 +224,8 @@ function main() {
 
     checks_arch
 
-    if [ -n "${ignore}" ]; then
-        common_logger -w "Hardware checks ignored."
-    else
-        common_logger "Verifying that your system meets the recommended minimum hardware requirements."
-        checks_health
-    fi
+    common_logger "Verifying that your system meets the recommended minimum hardware requirements."
+    checks_health
 
 
 # -------------- Preliminary checks and Prerequisites --------------------------------

--- a/tests/unit/test_checks.py
+++ b/tests/unit/test_checks.py
@@ -257,38 +257,38 @@ class TestChecksHealth:
     def test_success_no_installation(self):
         assert_success(self._run())
 
-    def test_fail_aio_1_core(self):
-        assert_failure(self._run({"AIO": "1", "cores": "1", "ram_gb": "15300"}))
+    def test_warn_aio_1_core(self):
+        assert_success(self._run({"AIO": "1", "cores": "1", "ram_gb": "15300"}))
 
-    def test_fail_aio_insufficient_ram(self):
-        assert_failure(self._run({"AIO": "1", "cores": "8", "ram_gb": "7300"}))
+    def test_warn_aio_insufficient_ram(self):
+        assert_success(self._run({"AIO": "1", "cores": "8", "ram_gb": "7300"}))
 
     def test_success_aio_8_cores_16gb(self):
         assert_success(self._run({"AIO": "1", "cores": "8", "ram_gb": "15300"}))
 
-    def test_fail_indexer_1_core(self):
-        assert_failure(self._run({"indexer": "1", "cores": "1", "ram_gb": "7300"}))
+    def test_warn_indexer_1_core(self):
+        assert_success(self._run({"indexer": "1", "cores": "1", "ram_gb": "7300"}))
 
-    def test_fail_indexer_insufficient_ram(self):
-        assert_failure(self._run({"indexer": "1", "cores": "4", "ram_gb": "3700"}))
+    def test_warn_indexer_insufficient_ram(self):
+        assert_success(self._run({"indexer": "1", "cores": "4", "ram_gb": "3700"}))
 
     def test_success_indexer_4_cores_8gb(self):
         assert_success(self._run({"indexer": "1", "cores": "4", "ram_gb": "7300"}))
 
-    def test_fail_dashboard_1_core(self):
-        assert_failure(self._run({"dashboard": "1", "cores": "1", "ram_gb": "3300"}))
+    def test_warn_dashboard_1_core(self):
+        assert_success(self._run({"dashboard": "1", "cores": "1", "ram_gb": "3300"}))
 
-    def test_fail_dashboard_insufficient_ram(self):
-        assert_failure(self._run({"dashboard": "1", "cores": "2", "ram_gb": "3000"}))
+    def test_warn_dashboard_insufficient_ram(self):
+        assert_success(self._run({"dashboard": "1", "cores": "2", "ram_gb": "3000"}))
 
     def test_success_dashboard_2_cores_enough_ram(self):
         assert_success(self._run({"dashboard": "1", "cores": "2", "ram_gb": "3300"}))
 
-    def test_fail_wazuh_1_core(self):
-        assert_failure(self._run({"wazuh": "1", "cores": "1", "ram_gb": "7300"}))
+    def test_warn_wazuh_1_core(self):
+        assert_success(self._run({"wazuh": "1", "cores": "1", "ram_gb": "7300"}))
 
-    def test_fail_wazuh_insufficient_ram(self):
-        assert_failure(self._run({"wazuh": "1", "cores": "4", "ram_gb": "3700"}))
+    def test_warn_wazuh_insufficient_ram(self):
+        assert_success(self._run({"wazuh": "1", "cores": "4", "ram_gb": "3700"}))
 
     def test_success_wazuh_4_cores_8gb(self):
         assert_success(self._run({"wazuh": "1", "cores": "4", "ram_gb": "7300"}))


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-installation-assistant/issues/811

# Description

The aim of this PR is to delete the `-i` | `--ignore-checks` optional parameter from the Installation Assistant.

The script will now log a warning message and continue with the installation.

## Tests

I deployed an AIO with an unsupported system (Ubuntu 22.04) and low resources (2GB ram and 1 CPU).

The warning messages are displayed but the installation continues.

Finally, the installation fails as expected because low resources.

<details>
<summary>Installation logs:</summary>

```shellsession
root@ubuntu-jammy:/home/vagrant# bash wazuh-install.sh -a -id -d pre-release
22/05/2026 15:04:21 INFO: Starting Wazuh installation assistant. Wazuh version: 5.0.0
22/05/2026 15:04:21 INFO: Verbose logging redirected to /var/log/wazuh-install.log
22/05/2026 15:04:22 INFO: The supported systems are: Red Hat Enterprise Linux 9, 10; Amazon Linux 2023; Ubuntu 24.04, 26.04.
22/05/2026 15:04:22 WARNING: The current system does not match with the list of supported systems. The installation may not work properly.
22/05/2026 15:04:28 INFO: --- Dependencies ----
22/05/2026 15:04:28 INFO: Installing apt-transport-https.
22/05/2026 15:04:31 INFO: Installing debhelper.
22/05/2026 15:04:35 INFO: Verifying that your system meets the recommended minimum hardware requirements.
22/05/2026 15:04:35 WARNING: Your system does not meet the recommended minimum hardware requirements of 16Gb of RAM and 8 CPU cores. The installation will continue, but it may not work properly.
22/05/2026 15:04:36 INFO: --- Configuration files ---
22/05/2026 15:04:36 INFO: Generating configuration files.
22/05/2026 15:04:36 INFO: Generating the root certificate.
22/05/2026 15:04:37 INFO: Generating Admin certificates.
22/05/2026 15:04:37 INFO: Generating Wazuh indexer certificates.
22/05/2026 15:04:37 INFO: Generating Wazuh manager certificates.
22/05/2026 15:04:37 INFO: Generating Wazuh dashboard certificates.
22/05/2026 15:04:38 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key and the certificates necessary for installation.
22/05/2026 15:04:38 INFO: --- Wazuh indexer ---
22/05/2026 15:04:38 INFO: Downloading wazuh_indexer package: wazuh-indexer_5.0.0-beta2_amd64.deb
22/05/2026 15:04:52 INFO: wazuh_indexer package downloaded successfully: /home/vagrant/wazuh-install-packages/wazuh-indexer_5.0.0-beta2_amd64.deb
22/05/2026 15:04:52 INFO: Starting Wazuh indexer installation.
22/05/2026 15:05:23 INFO: Wazuh indexer installation finished.
22/05/2026 15:05:23 INFO: Wazuh indexer post-install configuration finished.
22/05/2026 15:05:23 INFO: Starting service wazuh-indexer.
22/05/2026 15:06:10 INFO: wazuh-indexer service started.
22/05/2026 15:06:42 INFO: Wazuh indexer cluster security configuration initialized.
22/05/2026 15:06:42 INFO: --- Wazuh manager ---
22/05/2026 15:06:42 INFO: Downloading wazuh_manager package: wazuh-manager_5.0.0-beta2_amd64.deb
22/05/2026 15:06:44 INFO: wazuh_manager package downloaded successfully: /home/vagrant/wazuh-install-packages/wazuh-manager_5.0.0-beta2_amd64.deb
22/05/2026 15:06:44 INFO: Starting the Wazuh manager installation.
22/05/2026 15:07:39 INFO: Wazuh manager installation finished.
22/05/2026 15:07:39 INFO: Starting service wazuh-manager.
22/05/2026 15:07:50 INFO: wazuh-manager service started.
22/05/2026 15:07:50 INFO: --- Wazuh dashboard ---
22/05/2026 15:07:50 INFO: Downloading wazuh_dashboard package: wazuh-dashboard_5.0.0-beta2_amd64.deb
22/05/2026 15:07:53 INFO: wazuh_dashboard package downloaded successfully: /home/vagrant/wazuh-install-packages/wazuh-dashboard_5.0.0-beta2_amd64.deb
22/05/2026 15:07:53 INFO: Starting Wazuh dashboard installation.
22/05/2026 15:08:39 INFO: Wazuh dashboard installation finished.
22/05/2026 15:08:39 INFO: Wazuh dashboard post-install configuration finished.
22/05/2026 15:08:39 INFO: Starting service wazuh-dashboard.
22/05/2026 15:08:39 INFO: wazuh-dashboard service started.
22/05/2026 15:08:39 INFO: Wazuh dashboard web application initialized.
22/05/2026 15:08:39 INFO: --- Summary ---
22/05/2026 15:08:39 INFO: You can access the web interface https://<wazuh_dashboard_ip>:443
    User: admin
    Password: admin
22/05/2026 15:08:40 INFO: Installation finished.



root@ubuntu-jammy:/home/vagrant# systemctl status wazuh-indexer
× wazuh-indexer.service - wazuh-indexer
     Loaded: loaded (/lib/systemd/system/wazuh-indexer.service; enabled; vendor preset: enabled)
     Active: failed (Result: oom-kill) since Fri 2026-05-22 15:07:36 UTC; 3min 59s ago
       Docs: https://documentation.wazuh.com
   Main PID: 13166 (code=killed, signal=KILL)
        CPU: 1min 36.971s

May 22 15:05:29 ubuntu-jammy wazuh-indexer[13166]: WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
May 22 15:05:35 ubuntu-jammy wazuh-indexer[13166]: WARNING: A restricted method in java.lang.System has been called
May 22 15:05:35 ubuntu-jammy wazuh-indexer[13166]: WARNING: java.lang.System::load has been called by org.bouncycastle.crypto.fips.N>
May 22 15:05:35 ubuntu-jammy wazuh-indexer[13166]: WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in>
May 22 15:05:35 ubuntu-jammy wazuh-indexer[13166]: WARNING: Restricted methods will be blocked in a future release unless native acc>
May 22 15:06:10 ubuntu-jammy systemd[1]: Started wazuh-indexer.
May 22 15:07:35 ubuntu-jammy systemd[1]: wazuh-indexer.service: A process of this unit has been killed by the OOM killer.
May 22 15:07:36 ubuntu-jammy systemd[1]: wazuh-indexer.service: Main process exited, code=killed, status=9/KILL
May 22 15:07:36 ubuntu-jammy systemd[1]: wazuh-indexer.service: Failed with result 'oom-kill'.
May 22 15:07:36 ubuntu-jammy systemd[1]: wazuh-indexer.service: Consumed 1min 36.971s CPU time.



root@ubuntu-jammy:/home/vagrant# systemctl status wazuh-dashboard
● wazuh-dashboard.service - wazuh-dashboard
     Loaded: loaded (/lib/systemd/system/wazuh-dashboard.service; enabled; vendor preset: enabled)
     Active: active (running) since Fri 2026-05-22 15:08:39 UTC; 3min 4s ago
   Main PID: 33610 (node)
      Tasks: 11 (limit: 2307)
     Memory: 212.7M
        CPU: 5.040s
     CGroup: /system.slice/wazuh-dashboard.service
             └─33610 /usr/share/wazuh-dashboard/node/bin/node --no-warnings --max-http-header-size=65536 --unhandled-rejections=warn>

May 22 15:11:19 ubuntu-jammy opensearch-dashboards[33610]: {"type":"log","@timestamp":"2026-05-22T15:11:19Z","tags":["error","opense>
May 22 15:11:22 ubuntu-jammy opensearch-dashboards[33610]: {"type":"log","@timestamp":"2026-05-22T15:11:22Z","tags":["error","opense>
May 22 15:11:24 ubuntu-jammy opensearch-dashboards[33610]: {"type":"log","@timestamp":"2026-05-22T15:11:24Z","tags":["error","opense>
May 22 15:11:27 ubuntu-jammy opensearch-dashboards[33610]: {"type":"log","@timestamp":"2026-05-22T15:11:27Z","tags":["error","opense>
May 22 15:11:29 ubuntu-jammy opensearch-dashboards[33610]: {"type":"log","@timestamp":"2026-05-22T15:11:29Z","tags":["error","opense>
May 22 15:11:32 ubuntu-jammy opensearch-dashboards[33610]: {"type":"log","@timestamp":"2026-05-22T15:11:32Z","tags":["error","opense>
May 22 15:11:34 ubuntu-jammy opensearch-dashboards[33610]: {"type":"log","@timestamp":"2026-05-22T15:11:34Z","tags":["error","opense>
May 22 15:11:37 ubuntu-jammy opensearch-dashboards[33610]: {"type":"log","@timestamp":"2026-05-22T15:11:37Z","tags":["error","opense>
May 22 15:11:39 ubuntu-jammy opensearch-dashboards[33610]: {"type":"log","@timestamp":"2026-05-22T15:11:39Z","tags":["error","opense>
May 22 15:11:42 ubuntu-jammy opensearch-dashboards[33610]: {"type":"log","@timestamp":"2026-05-22T15:11:42Z","tags":["error","opense>



root@ubuntu-jammy:/home/vagrant# systemctl status wazuh-manager
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/lib/systemd/system/wazuh-manager.service; enabled; vendor preset: enabled)
     Active: active (running) since Fri 2026-05-22 15:07:50 UTC; 4min 0s ago
      Tasks: 145 (limit: 2307)
     Memory: 399.1M
        CPU: 10.753s
     CGroup: /system.slice/wazuh-manager.service
             ├─32723 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/api/scripts/wazuh_manager_apid.py
             ├─32739 /var/wazuh-manager/bin/wazuh-manager-authd
             ├─32751 /var/wazuh-manager/bin/wazuh-manager-db
             ├─32767 /var/wazuh-manager/bin/wazuh-manager-analysisd
             ├─32986 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/api/scripts/wazuh_manager_apid.py
             ├─32987 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/api/scripts/wazuh_manager_apid.py
             ├─32990 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/api/scripts/wazuh_manager_apid.py
             ├─33003 /var/wazuh-manager/bin/wazuh-manager-remoted
             ├─33033 /var/wazuh-manager/bin/wazuh-manager-monitord
             ├─33042 /var/wazuh-manager/bin/wazuh-manager-modulesd
             ├─33194 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/framework/scripts/wazuh_manager_clusterd.py
             └─33200 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/framework/scripts/wazuh_manager_clusterd.py

May 22 15:07:46 ubuntu-jammy env[32671]: Started wazuh-manager-apid...
May 22 15:07:46 ubuntu-jammy env[32671]: Started wazuh-manager-authd...
May 22 15:07:46 ubuntu-jammy env[32671]: Started wazuh-manager-db...
May 22 15:07:47 ubuntu-jammy env[32671]: Started wazuh-manager-analysisd...
May 22 15:07:47 ubuntu-jammy env[32671]: Started wazuh-manager-remoted...
May 22 15:07:47 ubuntu-jammy env[32671]: Started wazuh-manager-monitord...
```

</details>