### PR TITLE
Changed `run_as: false` to `true` in step-by-step documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Changed run_as: false to true in step-by-step documentation ([#834](https://github.com/wazuh/wazuh-installation-assistant/pull/834))
 - Updated test instances size. ([#804](https://github.com/wazuh/wazuh-installation-assistant/pull/804))
 - VD log message removed ([#795](https://github.com/wazuh/wazuh-installation-assistant/pull/795))
 - Fixed clusterized documentation for wazuh-install.sh download file. ([#794](https://github.com/wazuh/wazuh-installation-assistant/pull/794))

--- a/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md
+++ b/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md
@@ -321,7 +321,7 @@ The following dependencies must be installed on the Wazuh dashboard node:
         port: 55000
         username: wazuh-wui
         password: wazuh-wui
-        run_as: false
+        run_as: true
     ```
 
 3. Replace `<DASHBOARD_NODE_NAME>` with your Wazuh dashboard node name used in `config.yml` (for example, `dashboard`) and move the certificates.

--- a/docs/guide/step-by-step-deployments/all-in-one.md
+++ b/docs/guide/step-by-step-deployments/all-in-one.md
@@ -645,7 +645,7 @@ wazuh_core.hosts:
     port: 55000
     username: wazuh-wui
     password: wazuh-wui
-    run_as: false
+    run_as: true
 ```
 
 ### Deploying certificates

--- a/docs/guide/step-by-step-deployments/clusterized.md
+++ b/docs/guide/step-by-step-deployments/clusterized.md
@@ -755,7 +755,7 @@ wazuh_core.hosts:
     port: 55000
     username: wazuh-wui
     password: wazuh-wui
-    run_as: false
+    run_as: true
 ```
 
 ### Deploying certificates


### PR DESCRIPTION
## Description

The aim of this PR is to fix the step-by-step documentation guides that had the `run_as` variable set to `false` instead of `true` as it comes by default.

## Related issue
- https://github.com/wazuh/wazuh-installation-assistant/issues/829