### PR TITLE
Removed dashboard connection validation message, and dashboard_obtainNodeIp method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ All notable changes to this project will be documented in this file.
 
 ### Deleted
 
+- Removed dashboard connection validation message, and dashboard_obtainNodeIp method. ([#842](https://github.com/wazuh/wazuh-installation-assistant/pull/842))
 - Removed support for -i option in the Installation Assistant ([#817](https://github.com/wazuh/wazuh-installation-assistant/pull/817))
 - Removed old Wazuh installation assistant test workflows. ([#803](https://github.com/wazuh/wazuh-installation-assistant/pull/803))
 - Deleted yum-utils and lsof dependencies ([#692](https://github.com/wazuh/wazuh-installation-assistant/pull/692))

--- a/install_functions/dashboard.sh
+++ b/install_functions/dashboard.sh
@@ -80,7 +80,6 @@ function dashboard_copyCertificates() {
 
 function dashboard_displaySummary() {
 
-    common_logger "Wazuh dashboard web application initialized."
     common_logger -nl "--- Summary ---"
     common_logger -nl "You can access the web interface https://<wazuh_dashboard_ip>:${http_port}\n    User: admin\n    Password: admin"
 

--- a/install_functions/dashboard.sh
+++ b/install_functions/dashboard.sh
@@ -6,28 +6,11 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-function dashboard_obtainNodeIp() {
-
-    if [ -z "${dashboard_ip}" ]; then
-        if [ "${AIO}" ]; then
-            dashboard_ip="${dashboard_node_ips[0]}"
-        else
-            for i in "${!dashboard_node_names[@]}"; do
-                if [[ "${dashboard_node_names[i]}" == "${dashname}" ]]; then
-                    dashboard_ip=${dashboard_node_ips[i]};
-                    break
-                fi
-            done
-        fi
-    fi
-}
-
 function dashboard_configure() {
 
     common_logger -d "Configuring Wazuh dashboard."
 
     # dashboard configuration itself
-    dashboard_obtainNodeIp
     dashboard_copyCertificates "${debug}"
 
     # dashboard configuration to connect to the indexer cluster
@@ -96,10 +79,6 @@ function dashboard_copyCertificates() {
 }
 
 function dashboard_displaySummary() {
-
-    dashboard_obtainNodeIp
-
-    common_logger -d "Wazuh dashboard connection was successful."
 
     common_logger "Wazuh dashboard web application initialized."
     common_logger -nl "--- Summary ---"


### PR DESCRIPTION
close: https://github.com/wazuh/wazuh-installation-assistant/issues/836

## Description

Since connectivity validations with the dashboard are no longer performed after installation, we removed the outdated message.

We also removed the method for obtaining the dashboard's IP address, as it was no longer being used.

## Test

- https://github.com/wazuh/wazuh-installation-assistant/issues/836#issuecomment-4623535322