### PR TITLE
Fixed 5.0.0 branch references after bump

### DIFF
--- a/.github/workflows/builder_installation_assistant.yml
+++ b/.github/workflows/builder_installation_assistant.yml
@@ -7,7 +7,7 @@ on:
       wazuh_installation_assistant_reference:
         description: "Branch or tag of the wazuh-installation-assistant repository."
         required: true
-        default: 'v5.0.0-beta3'
+        default: '5.0.0'
       is_stage:
         description: "Is stage?"
         type: boolean
@@ -31,7 +31,7 @@ on:
         description: "Branch or tag of the wazuh-installation-assistant repository."
         type: string
         required: true
-        default: 'v5.0.0-beta3'
+        default: '5.0.0'
       is_stage:
         description: "Is stage?"
         type: boolean

--- a/.github/workflows/check_integration_tools.yaml
+++ b/.github/workflows/check_integration_tools.yaml
@@ -16,7 +16,7 @@ on:
       automation_reference:
         description: 'Branch of wazuh-automation to use'
         required: false
-        default: 'v5.0.0-beta3'
+        default: '5.0.0'
         type: string
       tool_type:
         description: 'Tool to test'


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-installation-assistant/issues/873

Fixed 5.0.0 branch references after bump