### PR TITLE
Fixed bumper including missing tag input

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -14,6 +14,11 @@ on:
         default: ''
         required: false
         type: string
+      tag:
+        description: 'Change branch references to tag-like references (e.g. v5.0.0-alpha7)'
+        default: false
+        required: false
+        type: boolean
       set_as_main:
         description: "Enable main branch mode: bump version values only, keep branch references pointing to main"
         required: false
@@ -86,22 +91,28 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           STAGE: ${{ inputs.stage }}
+          TAG: ${{ inputs.tag }}
         run: |
           script_params=""
           version=${{ env.VERSION }}
           stage=${{ env.STAGE }}
-
+          tag=${{ env.TAG }}
           set_as_main=${{ inputs.set_as_main }}
 
-          if [[ "$set_as_main" == "true" ]]; then
-            script_params="--set-as-main"
+          if [[ -n "$version" && -n "$stage" && "$tag" != "true" ]]; then
+            script_params="--version ${version} --stage ${stage}"
+          elif [[ -z "$version" && -n "$stage" && "$tag" == "true" ]]; then
+            script_params="--stage ${stage} --tag"
+          elif [[ -z "$version" && -z "$stage" && "$tag" == "true" ]]; then
+            script_params="--tag"
           fi
 
-          # Both version and stage provided
-          if [[ -n "$version" && -n "$stage" ]]; then
-            script_params+=" --version ${version} --stage ${stage}"
-          elif [[ -z "$version" && -n "$stage" ]]; then
-            script_params+=" --stage ${stage}"
+          if [[ "$set_as_main" == "true" ]]; then
+            if [[ -z "$version" || -z "$stage" ]]; then
+              echo "Error: set_as_main requires both version and stage inputs."
+              exit 1
+            fi
+            script_params="${script_params} --set-as-main"
           fi
 
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed bumper including missing tag input ([908](https://github.com/wazuh/wazuh-installation-assistant/pull/908))
 - Fix behavior with -d option when it has an empty parameter ([#830](https://github.com/wazuh/wazuh-installation-assistant/pull/830))
 - Update the OS compatibility matrix and ram specs ([#802](https://github.com/wazuh/wazuh-installation-assistant/pull/802))
 - Removed simple quote from manager.sh. ([#800](https://github.com/wazuh/wazuh-installation-assistant/pull/800))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed bumper including missing tag input ([908](https://github.com/wazuh/wazuh-installation-assistant/pull/908))
+- Fixed bumper including missing tag input ([#908](https://github.com/wazuh/wazuh-installation-assistant/pull/908))
 - Fix behavior with -d option when it has an empty parameter ([#830](https://github.com/wazuh/wazuh-installation-assistant/pull/830))
 - Update the OS compatibility matrix and ram specs ([#802](https://github.com/wazuh/wazuh-installation-assistant/pull/802))
 - Removed simple quote from manager.sh. ([#800](https://github.com/wazuh/wazuh-installation-assistant/pull/800))

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -9,6 +9,8 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOG_FILE="${DIR}/tools/repository_bumper_$(date +"%Y-%m-%d_%H-%M-%S-%3N").log"
 VERSION=""
 STAGE=""
+TAG=""
+REFERENCE=""
 FILES_EDITED=()
 FILES_EXCLUDED='--exclude="repository_bumper_*.log" --exclude="CHANGELOG.md" --exclude="metadata.json" --exclude="repository_bumper.sh" --exclude="Puppetfile" --exclude=".travis.yml" --exclude="Gemfile" --exclude="*_bumper_repository.yml" --exclude="mermaid-init.js" --exclude="mermaid.min.js"'
 
@@ -75,39 +77,45 @@ update_stage_in_files() {
             FILES_EDITED+=("${file}")
         fi
     done
-    if [ $STAGE != "alpha0" ]; then
-        version_tag_string="default: 'v${VERSION}'"
-        files_tag=( $(grep_command "${version_tag_string}" "${DIR}") )
-        for file in "${files_tag[@]}"; do
-            sed -i "s/${version_tag_string}/default: 'v${VERSION}-${STAGE}'/g" "${file}"
-            if [[ $(git diff --name-only "${file}") ]]; then
-                FILES_EDITED+=("${file}")
-            fi
-        done
+}
 
-        version_number_string="default: '${VERSION}'"
-        files_version=( $(grep -RlE "default: '[0-9]\.[0-9]+\.[0-9]+'" "${DIR}") )
-        for file in "${files_version[@]}"; do
-            sed -i "s/${version_number_string}/default: 'v${VERSION}-${STAGE}'/g" "${file}"
-            if [[ $(git diff --name-only "${file}") ]]; then
-                FILES_EDITED+=("${file}")
-            fi
-        done
+# Compute the value written into branch reference defaults ("default: '...'").
+# Without --tag, references stay branch-like (e.g. 5.0.0).
+# With --tag, references become tag-like (e.g. v5.0.0-beta3), or a plain release
+# tag (e.g. v5.0.0) when no stage is provided.
+build_reference() {
+    if [[ -n "$TAG" ]]; then
+        if [[ -z "$STAGE" ]]; then
+            REFERENCE="v${VERSION}"
+        else
+            REFERENCE="v${VERSION}-${STAGE}"
+        fi
+    else
+        REFERENCE="${VERSION}"
     fi
 }
 
+# Tag mode only: normalize every reference to the current version
+# (branch-like "5.0.0", "v5.0.0" or "v5.0.0-<stage>") into ${REFERENCE}.
+# Matching is restricted to "default: '...'" entries so plain version strings
+# elsewhere in the repository are left untouched.
+update_tag_references() {
+    local V_ESC="${VERSION//./\\.}"
+    files=( $(grep_command "${VERSION}" "${DIR}") )
+    for file in "${files[@]}"; do
+        sed -Ei "s/(default:[[:space:]]*')v?${V_ESC}(-[A-Za-z0-9]+)?(')/\1${REFERENCE}\3/g" "${file}"
+        if [[ $(git diff --name-only "${file}") ]]; then
+            FILES_EDITED+=("${file}")
+        fi
+    done
+}
+
 update_main_in_files() {
-    if [[ $STAGE == "alpha0" ]]; then
-            bump_string="default: '${VERSION}'"
-    else
-            bump_string="default: 'v${VERSION}'"
-    fi
-    main_string="default: 'main'"
+    local main_string="default: 'main'"
+    local bump_string="default: '${REFERENCE}'"
     files=( $(grep_command "${main_string}" "${DIR}") )
     for file in "${files[@]}"; do
-        if [[ "$skip_urls" != "yes" ]]; then
-            sed -Ei "s/${main_string}/${bump_string}/g" ${file}
-        fi
+        sed -Ei "s/${main_string}/${bump_string}/g" "${file}"
         if [[ $(git diff --name-only "${file}") ]]; then
             FILES_EDITED+=("${file}")
         fi
@@ -129,6 +137,10 @@ main() {
                 STAGE="$2"
                 shift 2
                 ;;
+            --tag)
+                TAG="yes"
+                shift 1
+                ;;
             --set-as-main)
                 set_as_main="yes"
                 shift 1
@@ -140,21 +152,32 @@ main() {
         esac
     done
 
-    # Set skip_urls variable based on set_as_main flag
-    if [[ -z "$set_as_main" ]]; then
-        echo "Updating version from main to $VERSION" | tee -a "${LOG_FILE}"
-        update_main_in_files "$VERSION" "$STAGE"
-    fi
-
-    # Validate arguments
-    if [[ -z "$VERSION" ]]; then
-        echo "Error: --version argument is required." | tee -a "${LOG_FILE}"
+    # --tag rewrites branch references into tag-like references (e.g. v5.0.0-beta3).
+    # It is mutually exclusive with --set-as-main, which keeps references on main.
+    if [[ -n "$TAG" && -n "$set_as_main" ]]; then
+        echo "Error: --tag cannot be combined with --set-as-main." | tee -a "${LOG_FILE}"
         exit 1
     fi
 
-    if [[ -z "$STAGE" ]]; then
-        echo "Error: --stage argument is required." | tee -a "${LOG_FILE}"
-        exit 1
+    # Read the current version/stage early: tag scenarios may omit --version and/or
+    # --stage and reuse the values already stored in VERSION.json.
+    get_old_version_and_stage
+
+    # Resolve and validate arguments depending on the mode
+    if [[ -n "$TAG" ]]; then
+        # Tag mode: version defaults to the current one; stage is optional
+        # (absent yields a release tag without a stage suffix).
+        [[ -z "$VERSION" ]] && VERSION="$OLD_VERSION"
+    else
+        # Branch mode: a full version + stage bump is required
+        if [[ -z "$VERSION" ]]; then
+            echo "Error: --version argument is required." | tee -a "${LOG_FILE}"
+            exit 1
+        fi
+        if [[ -z "$STAGE" ]]; then
+            echo "Error: --stage argument is required." | tee -a "${LOG_FILE}"
+            exit 1
+        fi
     fi
 
     # Validate if version is in the correct format
@@ -163,15 +186,24 @@ main() {
         exit 1
     fi
 
-    # Validate if stage is in the correct format
-    STAGE=$(echo "$STAGE" | tr '[:upper:]' '[:lower:]')
-    if ! [[ "$STAGE" =~ ^(alpha[0-9]*|beta[0-9]*|rc[0-9]*|stable)$ ]]; then
-        echo "Error: Stage must be one of the following examples: alpha1, beta1, rc1, stable." | tee -a "${LOG_FILE}"
-        exit 1
+    # Validate if stage is in the correct format (when provided)
+    if [[ -n "$STAGE" ]]; then
+        STAGE=$(echo "$STAGE" | tr '[:upper:]' '[:lower:]')
+        if ! [[ "$STAGE" =~ ^(alpha[0-9]*|beta[0-9]*|rc[0-9]*|stable)$ ]]; then
+            echo "Error: Stage must be one of the following examples: alpha1, beta1, rc1, stable." | tee -a "${LOG_FILE}"
+            exit 1
+        fi
     fi
 
-    # Get old version and stage
-    get_old_version_and_stage
+    # Compute the value written into branch reference defaults
+    build_reference
+    echo "Reference for branch defaults: ${REFERENCE}" | tee -a "${LOG_FILE}"
+
+    # Convert 'main' references unless they must keep pointing to main (set-as-main)
+    if [[ -z "$set_as_main" ]]; then
+        echo "Updating 'main' references to ${REFERENCE}" | tee -a "${LOG_FILE}"
+        update_main_in_files
+    fi
 
     if [[ "$OLD_VERSION" != "$VERSION" ]]; then
         echo "Updating version from $OLD_VERSION to $VERSION" | tee -a "${LOG_FILE}"
@@ -180,6 +212,11 @@ main() {
     if [[ -n "$STAGE" ]]; then
         echo "Updating stage from $OLD_STAGE to $STAGE" | tee -a "${LOG_FILE}"
         update_stage_in_files "$VERSION" "$STAGE"
+    fi
+    # Tag mode: normalize any remaining version references to the tag reference
+    if [[ -n "$TAG" ]]; then
+        echo "Updating version references to tag reference ${REFERENCE}" | tee -a "${LOG_FILE}"
+        update_tag_references
     fi
 
     echo "The following files were edited:" | tee -a "${LOG_FILE}"


### PR DESCRIPTION
## Related issue

- https://github.com/wazuh/wazuh-installation-assistant/issues/875

# Description

Adds `tag` support to the repository bumper so branch references are only rewritten to tag-like references (`v5.0.0-beta3`) when requested, and stay branch-like (`5.0.0`) on a normal bump.

- **Workflow** (`5_bumper_repository.yml`): new `tag` boolean input; parameter `if` reworked to map inputs to script flags; `set_as_main` guard (requires version + stage).
- **Script** (`repository_bumper.sh`): new `--tag` flag + `build_reference()` / `update_tag_references()`; `update_main_in_files()` now uses the computed reference; removed the old unconditional `v`-prefixing (the bug); `main()` reads `VERSION.json` early and validates per mode.
- Repo-specific `FILES_EXCLUDED` and `sed` variants preserved.

## Tests

- https://github.com/wazuh/wazuh-installation-assistant/issues/875#issuecomment-4841427874