### PR TITLE
The Wazuh indexer heap size was modified for the AIO installation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- The Wazuh indexer heap size was modified for the AIO installation. ([#917](https://github.com/wazuh/wazuh-installation-assistant/pull/917))
 - PR Revamp 5.0.0 ([#885](https://github.com/wazuh/wazuh-installation-assistant/issues/885))
 - Migrate GH runner to codebuild ([#876](https://github.com/wazuh/wazuh-installation-assistant/issues/876))
 - Minor change in step-by-step AIO documentation ([#855](https://github.com/wazuh/wazuh-installation-assistant/issues/855))

--- a/install_functions/indexer.sh
+++ b/install_functions/indexer.sh
@@ -12,7 +12,12 @@ function indexer_configure() {
 
     # Configure JVM options for Wazuh indexer
     ram_mb=$(free -m | awk 'FNR == 2 {print $2}')
-    ram="$(( ram_mb / 2 ))"
+
+    if [ "${AIO}" ]; then
+        ram="$(( ram_mb / 4 ))"
+    else
+        ram="$(( ram_mb / 2 ))"
+    fi
 
     if [ "${ram}" -eq "0" ]; then
         ram=1024;


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-installation-assistant/issues/915

## Description

The memory heap size configuration for Wazuh indexer has been modified. It is configured so that in AIO installation cases it is set to 1/4 of the memory, while in distributed installation cases the configuration of 1/2 of the memory is maintained.

## Tests

### AIO

- https://github.com/wazuh/wazuh-installation-assistant/issues/915#issuecomment-4877701326

### Distributed 

- https://github.com/wazuh/wazuh-installation-assistant/issues/915#issuecomment-4877749838