### PR TITLE
Adapt Allocator install and invocation to new Python package

### DIFF
--- a/.github/workflows/4_offline_installation.yml
+++ b/.github/workflows/4_offline_installation.yml
@@ -136,7 +136,7 @@ jobs:
         echo PATH=$PATH >> $GITHUB_ENV
 
     - name: Install and set allocator requirements
-      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
+      run: pip3 install ./wazuh-automation/deployability/modules/allocation
 
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v6
@@ -147,7 +147,7 @@ jobs:
     - name: Allocate test instance and set SSH variables
       id: allocator_instance
       run: |
-        python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir $ALLOCATOR_PATH \
+        wazuh-allocator --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir $ALLOCATOR_PATH \
           --track-output $ALLOCATOR_PATH/track.yml --inventory-output $ALLOCATOR_PATH/inventory.yml --instance-name gha_${{ env.COMPOSITE_NAME }}_${{ github.run_id }}_assistant_test \
           --label-team devops --label-termination-date 1d
 
@@ -223,4 +223,4 @@ jobs:
 
     - name: Delete allocated VM
       if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == true || github.event_name == 'pull_request')
-      run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output $ALLOCATOR_PATH/track.yml
+      run: wazuh-allocator --action delete --track-output $ALLOCATOR_PATH/track.yml

--- a/.github/workflows/4_test_installation_assistant.yml
+++ b/.github/workflows/4_test_installation_assistant.yml
@@ -151,12 +151,12 @@ jobs:
         path: wazuh-automation
 
     - name: Install and set allocator requirements
-      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
+      run: pip3 install ./wazuh-automation/deployability/modules/allocation
 
     - name: Allocate instance test and set SSH variables
       id: allocator_instance
       run: |
-        python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir $ALLOCATOR_PATH \
+        wazuh-allocator --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir $ALLOCATOR_PATH \
           --track-output $ALLOCATOR_PATH/track.yml --inventory-output $ALLOCATOR_PATH/inventory.yml --instance-name gha_${{ github.run_id }}_assistant_test \
           --label-team devops --label-termination-date 1d
 
@@ -226,4 +226,4 @@ jobs:
 
     - name: Delete allocated VM
       if: always() && steps.allocator_instance.outcome == 'success' && (inputs.DESTROY == true || github.event_name == 'pull_request')
-      run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output $ALLOCATOR_PATH/track.yml
+      run: wazuh-allocator --action delete --track-output $ALLOCATOR_PATH/track.yml

--- a/.github/workflows/4_test_installation_assistant_distributed.yml
+++ b/.github/workflows/4_test_installation_assistant_distributed.yml
@@ -156,7 +156,7 @@ jobs:
         path: wazuh-automation
 
     - name: Install and set allocator requirements
-      run: pip3 install -r wazuh-automation/deployability/deps/requirements.txt
+      run: pip3 install ./wazuh-automation/deployability/modules/allocation
 
     - name: Allocate instances and create inventory
       id: allocator_instance
@@ -179,7 +179,7 @@ jobs:
           instance_name=${instance_names[$i]}
           # Provision instance in parallel
           (
-            python3 wazuh-automation/deployability/modules/allocation/main.py \
+            wazuh-allocator \
               --action create --provider aws --size large \
               --composite-name ${{ env.COMPOSITE_NAME }} \
               --working-dir $ALLOCATOR_PATH --track-output $ALLOCATOR_PATH/track_${instance_name}.yml \
@@ -339,7 +339,7 @@ jobs:
 
           (
             # Delete instance
-            python3 wazuh-automation/deployability/modules/allocation/main.py \
+            wazuh-allocator \
               --action delete --provider aws --track-output $track_file
           ) &
         done

--- a/.github/workflows/5_check_integration_tools.yaml
+++ b/.github/workflows/5_check_integration_tools.yaml
@@ -320,7 +320,7 @@ jobs:
 
       - name: Install requirements
         run: |
-          pip install -r wazuh-automation/deployability/deps/requirements.txt
+          pip install ./wazuh-automation/deployability/modules/allocation
           pip install -r wazuh-automation/integration-test-module/requirements.txt
           pip install -e wazuh-automation/integration-test-module/
 
@@ -338,7 +338,7 @@ jobs:
         id: allocate
         run: |
           mkdir -p ${{ env.ALLOCATOR_PATH }}
-          python3 wazuh-automation/deployability/modules/allocation/main.py \
+          wazuh-allocator \
             --action create \
             --provider aws \
             --size xlarge \
@@ -886,7 +886,7 @@ jobs:
       - name: Deallocate instance
         if: always()
         run: |
-          python3 wazuh-automation/deployability/modules/allocation/main.py \
+          wazuh-allocator \
             --action delete \
             --track-output ${{ env.ALLOCATOR_PATH }}/track.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#974](https://github.com/wazuh/wazuh-installation-assistant/pull/974) | Adapt Allocator install and invocation to the new installable Python package |
 | [#972](https://github.com/wazuh/wazuh-installation-assistant/issues/972) | Change Codebuild runners to Github runners |
 | [#909](https://github.com/wazuh/wazuh-installation-assistant/issues/909) | Change upload and download methods |
 | [#928](https://github.com/wazuh/wazuh-installation-assistant/issues/928) | Update deployment for Wazuh Indexer 5.0.0 RBAC. |

--- a/docs/ref/integration_test/installation_assistant_integration_tests.md
+++ b/docs/ref/integration_test/installation_assistant_integration_tests.md
@@ -146,7 +146,7 @@ Runs once per OS in the matrix. Each instance provisions its own VM and runs ind
 Provisions a dedicated AWS VM using the `deployability` allocator:
 
 ```bash
-python3 wazuh-automation/deployability/modules/allocation/main.py \
+wazuh-allocator \
   --action create \
   --provider aws \
   --size xlarge \
@@ -261,7 +261,7 @@ For details on what each test type validates, see the `Integration Test Module â
 Deallocates the VM:
 
 ```bash
-python3 wazuh-automation/deployability/modules/allocation/main.py \
+wazuh-allocator \
   --action delete \
   --track-output {ALLOCATOR_PATH}/track.yml
 ```


### PR DESCRIPTION
Updates all four affected workflows (`4_test_installation_assistant_distributed.yml`, `4_offline_installation.yml`, `4_test_installation_assistant.yml`, `5_check_integration_tools.yaml`) to use the Allocator's new package interface: installs it via `pip install ./wazuh-automation/deployability/modules/allocation` instead of the removed `requirements.txt`, and switches all create/delete invocations from direct `main.py` execution to the `wazuh-allocator` console entry point. 

## Related to:
https://github.com/wazuh/internal-devel-requests/issues/5888