### PR TITLE
Deploy manager indexer certificates as root:wazuh-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#970](https://github.com/wazuh/wazuh-installation-assistant/issues/970) | Deploy manager indexer certificates as root:wazuh-manager |
 | [#972](https://github.com/wazuh/wazuh-installation-assistant/issues/972) | Change Codebuild runners to Github runners |
 | [#909](https://github.com/wazuh/wazuh-installation-assistant/issues/909) | Change upload and download methods |
 | [#928](https://github.com/wazuh/wazuh-installation-assistant/issues/928) | Update deployment for Wazuh Indexer 5.0.0 RBAC. |

--- a/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md
+++ b/docs/guide/offline-step-by-step-deployments/offline-step-by-step.md
@@ -152,11 +152,16 @@ On systems with apt as package manager, the following dependencies must be insta
     ```BASH
     mkdir -p /var/wazuh-manager/etc/certs
     cp ./wazuh-certificates/root-ca.pem /var/wazuh-manager/etc/certs/root-ca.pem
-    mv ./wazuh-certificates/$NODE_NAME.pem /var/wazuh-manager/etc/certs/manager.pem
-    mv ./wazuh-certificates/$NODE_NAME-key.pem /var/wazuh-manager/etc/certs/manager-key.pem
-    chmod 500 /var/wazuh-manager/etc/certs
-    chmod 400 /var/wazuh-manager/etc/certs/*
-    chown -R wazuh-manager:wazuh-manager /var/wazuh-manager/etc/certs
+    mv ./wazuh-certificates/$NODE_NAME.pem /var/wazuh-manager/etc/certs/indexer-connector.pem
+    mv ./wazuh-certificates/$NODE_NAME-key.pem /var/wazuh-manager/etc/certs/indexer-connector-key.pem
+    chown root:wazuh-manager /var/wazuh-manager/etc/certs/root-ca.pem \
+        /var/wazuh-manager/etc/certs/indexer-connector.pem \
+        /var/wazuh-manager/etc/certs/indexer-connector-key.pem
+    chmod 640 /var/wazuh-manager/etc/certs/root-ca.pem \
+        /var/wazuh-manager/etc/certs/indexer-connector.pem \
+        /var/wazuh-manager/etc/certs/indexer-connector-key.pem
+    chown root:wazuh-manager /var/wazuh-manager/etc/certs
+    chmod 1770 /var/wazuh-manager/etc/certs
     ```
 
     > [!NOTE]
@@ -182,8 +187,8 @@ On systems with apt as package manager, the following dependencies must be insta
         <certificate_authorities>
         <ca>etc/certs/root-ca.pem</ca>
         </certificate_authorities>
-        <certificate>etc/certs/manager.pem</certificate>
-        <key>etc/certs/manager-key.pem</key>
+        <certificate>etc/certs/indexer-connector.pem</certificate>
+        <key>etc/certs/indexer-connector-key.pem</key>
     </ssl>
     </indexer>
     ```

--- a/docs/guide/step-by-step-deployments/all-in-one.md
+++ b/docs/guide/step-by-step-deployments/all-in-one.md
@@ -438,11 +438,16 @@ NODE_NAME=<MANAGER_NODE_NAME>
 ```bash
 mkdir -p /var/wazuh-manager/etc/certs
 cp ./wazuh-certificates/root-ca.pem /var/wazuh-manager/etc/certs/root-ca.pem
-mv ./wazuh-certificates/$NODE_NAME.pem /var/wazuh-manager/etc/certs/manager.pem
-mv ./wazuh-certificates/$NODE_NAME-key.pem /var/wazuh-manager/etc/certs/manager-key.pem
-chmod 500 /var/wazuh-manager/etc/certs
-chmod 400 /var/wazuh-manager/etc/certs/*
-chown -R wazuh-manager:wazuh-manager /var/wazuh-manager/etc/certs
+mv ./wazuh-certificates/$NODE_NAME.pem /var/wazuh-manager/etc/certs/indexer-connector.pem
+mv ./wazuh-certificates/$NODE_NAME-key.pem /var/wazuh-manager/etc/certs/indexer-connector-key.pem
+chown root:wazuh-manager /var/wazuh-manager/etc/certs/root-ca.pem \
+    /var/wazuh-manager/etc/certs/indexer-connector.pem \
+    /var/wazuh-manager/etc/certs/indexer-connector-key.pem
+chmod 640 /var/wazuh-manager/etc/certs/root-ca.pem \
+    /var/wazuh-manager/etc/certs/indexer-connector.pem \
+    /var/wazuh-manager/etc/certs/indexer-connector-key.pem
+chown root:wazuh-manager /var/wazuh-manager/etc/certs
+chmod 1770 /var/wazuh-manager/etc/certs
 ```
 
 > [!NOTE]
@@ -468,8 +473,8 @@ Update the indexer configuration in `/var/wazuh-manager/etc/wazuh-manager.conf` 
     <certificate_authorities>
       <ca>etc/certs/root-ca.pem</ca>
     </certificate_authorities>
-    <certificate>etc/certs/manager.pem</certificate>
-    <key>etc/certs/manager-key.pem</key>
+    <certificate>etc/certs/indexer-connector.pem</certificate>
+    <key>etc/certs/indexer-connector-key.pem</key>
   </ssl>
 </indexer>
 ```

--- a/docs/guide/step-by-step-deployments/clusterized.md
+++ b/docs/guide/step-by-step-deployments/clusterized.md
@@ -477,11 +477,16 @@ NODE_NAME=<MANAGER_NODE_NAME>
 ```bash
 mkdir -p /var/wazuh-manager/etc/certs
 tar -xf wazuh-certificates.tar -C /var/wazuh-manager/etc/certs/ ./$NODE_NAME.pem ./$NODE_NAME-key.pem ./root-ca.pem
-mv -n /var/wazuh-manager/etc/certs/$NODE_NAME.pem /var/wazuh-manager/etc/certs/manager.pem
-mv -n /var/wazuh-manager/etc/certs/$NODE_NAME-key.pem /var/wazuh-manager/etc/certs/manager-key.pem
-chmod 500 /var/wazuh-manager/etc/certs
-chmod 400 /var/wazuh-manager/etc/certs/*
-chown -R wazuh-manager:wazuh-manager /var/wazuh-manager/etc/certs
+mv -n /var/wazuh-manager/etc/certs/$NODE_NAME.pem /var/wazuh-manager/etc/certs/indexer-connector.pem
+mv -n /var/wazuh-manager/etc/certs/$NODE_NAME-key.pem /var/wazuh-manager/etc/certs/indexer-connector-key.pem
+chown root:wazuh-manager /var/wazuh-manager/etc/certs/root-ca.pem \
+    /var/wazuh-manager/etc/certs/indexer-connector.pem \
+    /var/wazuh-manager/etc/certs/indexer-connector-key.pem
+chmod 640 /var/wazuh-manager/etc/certs/root-ca.pem \
+    /var/wazuh-manager/etc/certs/indexer-connector.pem \
+    /var/wazuh-manager/etc/certs/indexer-connector-key.pem
+chown root:wazuh-manager /var/wazuh-manager/etc/certs
+chmod 1770 /var/wazuh-manager/etc/certs
 ```
 
 > [!NOTE]
@@ -507,8 +512,8 @@ Update the indexer configuration in `/var/wazuh-manager/etc/wazuh-manager.conf` 
     <certificate_authorities>
       <ca>etc/certs/root-ca.pem</ca>
     </certificate_authorities>
-    <certificate>etc/certs/manager.pem</certificate>
-    <key>etc/certs/manager-key.pem</key>
+    <certificate>etc/certs/indexer-connector.pem</certificate>
+    <key>etc/certs/indexer-connector-key.pem</key>
   </ssl>
 </indexer>
 ```

--- a/install_functions/manager.sh
+++ b/install_functions/manager.sh
@@ -57,8 +57,8 @@ function manager_configure(){
     if [ "${AIO}" ]; then
         winame="${manager_node_names[0]}"
     fi
-    eval "sed -i s/manager.pem/${winame}.pem/ /var/wazuh-manager/etc/wazuh-manager.conf ${debug}"
-    eval "sed -i s/manager-key.pem/${winame}-key.pem/ /var/wazuh-manager/etc/wazuh-manager.conf ${debug}"
+    eval "sed -i s/manager.pem/indexer-connector.pem/ /var/wazuh-manager/etc/wazuh-manager.conf ${debug}"
+    eval "sed -i s/manager-key.pem/indexer-connector-key.pem/ /var/wazuh-manager/etc/wazuh-manager.conf ${debug}"
     manager_copyCertificates "${debug}"
     common_logger -d "Setting provisional Wazuh indexer password."
     /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k username -v wazuh-manager
@@ -120,10 +120,13 @@ function manager_copyCertificates() {
         eval "tar -xf ${tar_file} -C ${manager_cert_path} wazuh-install-files/${winame}.pem --strip-components 1 ${debug}"
         eval "tar -xf ${tar_file} -C ${manager_cert_path} wazuh-install-files/${winame}-key.pem --strip-components 1 ${debug}"
         eval "tar -xf ${tar_file} -C ${manager_cert_path} wazuh-install-files/root-ca.pem --strip-components 1 ${debug}"
+        eval "mv ${manager_cert_path}/${winame}.pem ${manager_cert_path}/indexer-connector.pem ${debug}"
+        eval "mv ${manager_cert_path}/${winame}-key.pem ${manager_cert_path}/indexer-connector-key.pem ${debug}"
         eval "rm -rf ${manager_cert_path}/wazuh-install-files/ ${debug}"
-        eval "chown -R wazuh-manager:wazuh-manager ${manager_cert_path} ${debug}"
-        eval "chmod 500 ${manager_cert_path} ${debug}"
-        eval "chmod 400 ${manager_cert_path}/* ${debug}"
+        eval "chown root:wazuh-manager ${manager_cert_path}/root-ca.pem ${manager_cert_path}/indexer-connector.pem ${manager_cert_path}/indexer-connector-key.pem ${debug}"
+        eval "chmod 640 ${manager_cert_path}/root-ca.pem ${manager_cert_path}/indexer-connector.pem ${manager_cert_path}/indexer-connector-key.pem ${debug}"
+        eval "chown root:wazuh-manager ${manager_cert_path} ${debug}"
+        eval "chmod 1770 ${manager_cert_path} ${debug}"
     else
         common_logger -e "No certificates found. Could not initialize Wazuh manager"
         installCommon_rollBack


### PR DESCRIPTION
## Description

Updates `manager_copyCertificates` / `manager_configure` in `install_functions/manager.sh` so the manager's indexer trust material is deployed with the ownership/mode required by wazuh/wazuh#38278, instead of the blanket `wazuh-manager:wazuh-manager` / `500`/`400` from #673:

- `root-ca.pem`, `indexer-connector.pem`, `indexer-connector-key.pem` → `root:wazuh-manager`, `0640`.
- `/var/wazuh-manager/etc/certs` → `root:wazuh-manager`, `1770`.
- Self-generated `authd.*`/`remoted.*`/`apid.*` are left untouched (`wazuh-manager:wazuh-manager`).
- `${winame}.pem`/`${winame}-key.pem` are renamed to `indexer-connector.pem`/`indexer-connector-key.pem`, and `wazuh-manager.conf` is updated to reference the new filenames.

Docs updated accordingly (AIO, clusterized, offline step-by-step).

## Testing

Manually verified with the wazuh-automation allocator in two topologies:

- All-in-one (single node): https://github.com/wazuh/wazuh-installation-assistant/issues/970#issuecomment-5315431861
- Distributed (2 indexers, 2 managers master+worker, dashboard, agent): https://github.com/wazuh/wazuh-installation-assistant/issues/970#issuecomment-5316581171

Both confirm the certs end up with the expected ownership/mode on every manager node, and the cluster/dashboard/agent come up healthy.
