### PR TITLE
Restore #950 changelog entry dropped by the #954 format rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#950](https://github.com/wazuh/wazuh-installation-assistant/issues/950) | Align the passwords tool minimum length with the 12-character Wazuh server API policy |
 | [#976](https://github.com/wazuh/wazuh-installation-assistant/pull/976) | Report skipped bumps in the repository bumper workflow |
 | [#956](https://github.com/wazuh/wazuh-installation-assistant/issues/956) | Fixed changelog check workflow to accept Prior versions entries |
 | [#933](https://github.com/wazuh/wazuh-installation-assistant/issues/933) | E2E Documentation issues in Release 5.0.0. |


### PR DESCRIPTION
PR #954 rewrote the CHANGELOG.md format based on an older version of the file, silently dropping the entry that #951 had added for #950 (passwords tool minimum length aligned with the 12-character server API policy). Restoring it under `### Fixed`.
