### PR TITLE
Remove test_check_wazuh_manager_monitord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#992](https://github.com/wazuh/wazuh-installation-assistant/issues/992) | Remove test_check_wazuh_manager_monitord, daemon retired in 5.0.0 |
 | [#950](https://github.com/wazuh/wazuh-installation-assistant/issues/950) | Align the passwords tool minimum length with the 12-character Wazuh server API policy |
 | [#976](https://github.com/wazuh/wazuh-installation-assistant/pull/976) | Report skipped bumps in the repository bumper workflow |
 | [#956](https://github.com/wazuh/wazuh-installation-assistant/issues/956) | Fixed changelog check workflow to accept Prior versions entries |

--- a/tests/install/test_installation_assistant.py
+++ b/tests/install/test_installation_assistant.py
@@ -150,10 +150,6 @@ def test_check_wazuh_manager_remoted():
     assert check_call("ps -xa | grep wazuh-manager-remoted | grep -v grep", shell=True) != ""
 
 @pytest.mark.wazuh
-def test_check_wazuh_manager_monitord():
-    assert check_call("ps -xa | grep wazuh-manager-monitord | grep -v grep", shell=True) != ""
-
-@pytest.mark.wazuh
 def test_check_wazuh_manager_modulesd():
     assert check_call("ps -xa | grep wazuh-manager-modulesd | grep -v grep", shell=True) != ""
 


### PR DESCRIPTION
## Summary
- `wazuh-manager-monitord` was retired in wazuh/wazuh#38757 (5.0.0, rc1) — its responsibilities moved to a manager-side Task Manager (wazuh/wazuh#38589).
- `test_check_wazuh_manager_monitord` hardcoded a check for that daemon's process, which no longer exists, so it fails on every install run against 5.0.0.
- `test_check_wazuh_manager_modulesd` already covers the daemon that inherited part of its role, so no replacement test is added.

## Test plan
- [x] Verified via `5_check_integration_tools.yaml` — [run 33765968582](https://github.com/wazuh/wazuh-installation-assistant/actions/runs/33765968582), AIO install + uninstall on `ubuntu-22-amd64`. Overall Status: PASS.

Closes #992