### PR TITLE
Fix duplicate types/branches keys in 4_test_installation_assistant.yml pull_request trigger

### DIFF
--- a/.github/workflows/4_test_installation_assistant.yml
+++ b/.github/workflows/4_test_installation_assistant.yml
@@ -54,7 +54,7 @@ env:
   WAZUH_INSTALLATION_ASSISTANT_REFERENCE: ${{ github.event_name == 'pull_request' && github.head_ref || inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}
   AUTOMATION_REFERENCE: ${{ github.event_name == 'pull_request' && 'v4.14.5' || inputs.AUTOMATION_REFERENCE }}
   VERBOSITY: ${{ github.event_name == 'pull_request' && '-v' || inputs.VERBOSITY }}
-  COMPOSITE_NAME: "linux-SUBNAME-amd64"
+  COMPOSITE_NAME: "SUBNAME-amd64"
   SESSION_NAME: "Installation-Assistant-Test"
   REGION: "us-east-1"
   TMP_PATH: "/tmp/test"

--- a/.github/workflows/4_test_installation_assistant.yml
+++ b/.github/workflows/4_test_installation_assistant.yml
@@ -13,9 +13,6 @@ on:
       - 'install_functions/**'
       - 'passwords_tool/**'
       - 'tests/**'
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - 4.*
   workflow_dispatch:
     inputs:
       REPOSITORY:


### PR DESCRIPTION
## Summary
- `pull_request:` in `4_test_installation_assistant.yml` had `types:` and `branches:` defined twice — invalid YAML.
- GitHub falls back to treating the workflow as push-triggered in that case: it fires (and fails instantly) on every push instead of only on PRs to `4.*`, and rejects `workflow_dispatch` runs outright (confirmed while trying to manually dispatch it to validate #992).
- Removes the duplicate block, keeping the single valid `pull_request` trigger with `types`, `branches`, and `paths`.
