### PR TITLE
Fix silent manager restart failures and API race condition

### DIFF
--- a/.github/workflows/ansible-playbooks/aio.yml
+++ b/.github/workflows/ansible-playbooks/aio.yml
@@ -13,5 +13,5 @@
         args:
           chdir: "{{ script_path }}"
         register: install_results
-        async: 500
+        async: 800
         poll: 5

--- a/.github/workflows/ansible-playbooks/distributed_install_wazuh.yml
+++ b/.github/workflows/ansible-playbooks/distributed_install_wazuh.yml
@@ -24,7 +24,7 @@
             delay: 30
             timeout: 300
           when: hostvars[inventory_hostname].manager_type == 'worker'
-          async: 500
+          async: 800
           poll: 5
 
         - name: Install Wazuh server (Workers)

--- a/.github/workflows/ansible-playbooks/offline-installation/test.yml
+++ b/.github/workflows/ansible-playbooks/offline-installation/test.yml
@@ -23,5 +23,5 @@
       args:
         chdir: "{{ working_path }}"
       register: install_results
-      async: 500
+      async: 800
       poll: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Fix silent manager restart failures and API user registration race condition causing false "User wazuh is not registered in Wazuh API" errors. ([#1010](https://github.com/wazuh/wazuh-installation-assistant/pull/1010))
 
 ### Deleted
 

--- a/passwords_tool/passwordsFunctions.sh
+++ b/passwords_tool/passwordsFunctions.sh
@@ -557,7 +557,7 @@ function passwords_isServiceActive() {
         # wazuh-maild, wazuh-agentlessd, wazuh-integratord and
         # wazuh-csyslogd are optional and off by default, so they are
         # intentionally left out of this check.
-        manager_core_daemons=(wazuh-execd wazuh-db wazuh-analysisd wazuh-syscheckd wazuh-remoted wazuh-logcollector wazuh-monitord wazuh-modulesd wazuh-apid)
+        manager_core_daemons=(wazuh-execd wazuh-db wazuh-analysisd wazuh-syscheckd wazuh-remoted wazuh-logcollector wazuh-monitord wazuh-modulesd wazuh-apid wazuh-authd)
         manager_status=$(/var/ossec/bin/wazuh-control status 2>/dev/null)
         for manager_daemon in "${manager_core_daemons[@]}"; do
             if ! echo "${manager_status}" | grep -q "^${manager_daemon} is running"; then

--- a/passwords_tool/passwordsFunctions.sh
+++ b/passwords_tool/passwordsFunctions.sh
@@ -351,7 +351,30 @@ function passwords_getApiUsers() {
 }
 
 function passwords_getApiUserId() {
-    user_id=$(common_curl -s -k -H \"Authorization: Bearer $TOKEN_API\" -H \"Content-Type: application/json\" \"https://localhost:55000/security/users?pretty=true\" | grep -B2 -A2 "\"username\": \"${1}\"" | grep '"id"' | grep -o '[0-9]\+')
+
+    # The manager can respond on the API port right after restarting while
+    # it is still registering its internal users. A single lookup here can
+    # race that registration and report a false "not registered" error
+    # (see external-devel-requests#6840). Poll for a short, bounded window
+    # instead of failing on the first empty response.
+    api_user_lookup_retries=12
+    api_user_lookup_delay=5
+    api_user_lookup_attempt=0
+    user_id=""
+
+    while [ "${api_user_lookup_attempt}" -lt "${api_user_lookup_retries}" ]; do
+        user_id=$(common_curl -s -k -H \"Authorization: Bearer $TOKEN_API\" -H \"Content-Type: application/json\" \"https://localhost:55000/security/users?pretty=true\" | grep -B2 -A2 "\"username\": \"${1}\"" | grep '"id"' | grep -o '[0-9]\+')
+
+        if [ -n "${user_id}" ]; then
+            break
+        fi
+
+        api_user_lookup_attempt=$((api_user_lookup_attempt+1))
+        if [ "${api_user_lookup_attempt}" -lt "${api_user_lookup_retries}" ]; then
+            common_logger -d "User ${1} not found yet in the Wazuh API (attempt ${api_user_lookup_attempt}/${api_user_lookup_retries}). The API may still be registering internal users, retrying in ${api_user_lookup_delay}s."
+            sleep "${api_user_lookup_delay}"
+        fi
+    done
 
     if [ -z "${user_id}" ]; then
         common_logger -e "User ${1} is not registered in Wazuh API"

--- a/passwords_tool/passwordsFunctions.sh
+++ b/passwords_tool/passwordsFunctions.sh
@@ -609,7 +609,36 @@ function passwords_restartService() {
             fi
             exit 1;
         else
-            common_logger -d "${1} started."
+            # Same rationale as the systemd branch above: the restart command
+            # can return success immediately even if the service later fails
+            # to initialize. Poll the init script's own status action for a
+            # short window before considering the restart actually successful.
+            restart_check_retries=12
+            restart_check_delay=5
+            restart_check_attempt=0
+            service_is_active=""
+
+            while [ "${restart_check_attempt}" -lt "${restart_check_retries}" ]; do
+                if eval "/etc/init.d/${1} status ${debug}"; then
+                    service_is_active="true"
+                    break
+                fi
+                restart_check_attempt=$((restart_check_attempt+1))
+                sleep "${restart_check_delay}"
+            done
+
+            if [ -z "${service_is_active}" ]; then
+                common_logger -e "${1} restarted but did not stay active (checked for $((restart_check_retries * restart_check_delay))s). It may have failed to initialize, for example due to insufficient resources."
+                if [ -n "$(command -v journalctl)" ]; then
+                    eval "journalctl -u ${1} >> ${logfile}"
+                fi
+                if [[ $(type -t installCommon_rollBack) == "function" ]]; then
+                    installCommon_rollBack
+                fi
+                exit 1;
+            else
+                common_logger -d "${1} started."
+            fi
         fi
     elif [ -x "/etc/rc.d/init.d/${1}" ] ; then
         eval "/etc/rc.d/init.d/${1} restart ${debug}"
@@ -623,7 +652,35 @@ function passwords_restartService() {
             fi
             exit 1;
         else
-            common_logger -d "${1} started."
+            # Same rationale as the systemd branch above: poll the init
+            # script's own status action for a short window before
+            # considering the restart actually successful.
+            restart_check_retries=12
+            restart_check_delay=5
+            restart_check_attempt=0
+            service_is_active=""
+
+            while [ "${restart_check_attempt}" -lt "${restart_check_retries}" ]; do
+                if eval "/etc/rc.d/init.d/${1} status ${debug}"; then
+                    service_is_active="true"
+                    break
+                fi
+                restart_check_attempt=$((restart_check_attempt+1))
+                sleep "${restart_check_delay}"
+            done
+
+            if [ -z "${service_is_active}" ]; then
+                common_logger -e "${1} restarted but did not stay active (checked for $((restart_check_retries * restart_check_delay))s). It may have failed to initialize, for example due to insufficient resources."
+                if [ -n "$(command -v journalctl)" ]; then
+                    eval "journalctl -u ${1} >> ${logfile}"
+                fi
+                if [[ $(type -t installCommon_rollBack) == "function" ]]; then
+                    installCommon_rollBack
+                fi
+                exit 1;
+            else
+                common_logger -d "${1} started."
+            fi
         fi
     else
         if [[ $(type -t installCommon_rollBack) == "function" ]]; then

--- a/passwords_tool/passwordsFunctions.sh
+++ b/passwords_tool/passwordsFunctions.sh
@@ -554,10 +554,10 @@ function passwords_isServiceActive() {
     # wazuh-control status reflects each daemon's real state instead.
     if [ "${1}" == "wazuh-manager" ] && [ -x /var/ossec/bin/wazuh-control ]; then
         # Daemons enabled by default on every install. wazuh-clusterd,
-        # wazuh-maild, wazuh-agentlessd, wazuh-integratord and
-        # wazuh-csyslogd are optional and off by default, so they are
+        # wazuh-maild, wazuh-agentlessd, wazuh-integratord, wazuh-csyslogd
+        # and wazuh-authd are optional/configurable, so they are
         # intentionally left out of this check.
-        manager_core_daemons=(wazuh-execd wazuh-db wazuh-analysisd wazuh-syscheckd wazuh-remoted wazuh-logcollector wazuh-monitord wazuh-modulesd wazuh-apid wazuh-authd)
+        manager_core_daemons=(wazuh-execd wazuh-db wazuh-analysisd wazuh-syscheckd wazuh-remoted wazuh-logcollector wazuh-monitord wazuh-modulesd wazuh-apid)
         manager_status=$(/var/ossec/bin/wazuh-control status 2>/dev/null)
         for manager_daemon in "${manager_core_daemons[@]}"; do
             if ! echo "${manager_status}" | grep -q "^${manager_daemon} is running"; then

--- a/passwords_tool/passwordsFunctions.sh
+++ b/passwords_tool/passwordsFunctions.sh
@@ -544,6 +544,43 @@ function passwords_readUsers() {
 
 }
 
+function passwords_isServiceActive() {
+
+    # wazuh-manager is Type=forking with RemainAfterExit=yes and no PIDFile,
+    # so systemd (and the equivalent SysV init status action) only require
+    # *some* forked process from the unit's cgroup to still be alive to keep
+    # reporting it as active/running -- e.g. wazuh-apid on its own, even if
+    # the core daemons (analysisd, remoted, etc.) already crashed. Checking
+    # wazuh-control status reflects each daemon's real state instead.
+    if [ "${1}" == "wazuh-manager" ] && [ -x /var/ossec/bin/wazuh-control ]; then
+        # Daemons enabled by default on every install. wazuh-clusterd,
+        # wazuh-maild, wazuh-agentlessd, wazuh-integratord and
+        # wazuh-csyslogd are optional and off by default, so they are
+        # intentionally left out of this check.
+        manager_core_daemons=(wazuh-execd wazuh-db wazuh-analysisd wazuh-syscheckd wazuh-remoted wazuh-logcollector wazuh-monitord wazuh-modulesd wazuh-apid)
+        manager_status=$(/var/ossec/bin/wazuh-control status 2>/dev/null)
+        for manager_daemon in "${manager_core_daemons[@]}"; do
+            if ! echo "${manager_status}" | grep -q "^${manager_daemon} is running"; then
+                return 1
+            fi
+        done
+        return 0
+    fi
+
+    case "${2}" in
+        systemd)
+            systemctl is-active --quiet "${1}.service"
+            ;;
+        initd)
+            eval "/etc/init.d/${1} status ${debug}"
+            ;;
+        rcd)
+            eval "/etc/rc.d/init.d/${1} status ${debug}"
+            ;;
+    esac
+
+}
+
 function passwords_restartService() {
 
     common_logger -d "Restarting ${1} service..."
@@ -576,7 +613,7 @@ function passwords_restartService() {
             service_is_active=""
 
             while [ "${restart_check_attempt}" -lt "${restart_check_retries}" ]; do
-                if systemctl is-active --quiet "${1}.service"; then
+                if passwords_isServiceActive "${1}" systemd; then
                     service_is_active="true"
                     break
                 fi
@@ -619,7 +656,7 @@ function passwords_restartService() {
             service_is_active=""
 
             while [ "${restart_check_attempt}" -lt "${restart_check_retries}" ]; do
-                if eval "/etc/init.d/${1} status ${debug}"; then
+                if passwords_isServiceActive "${1}" initd; then
                     service_is_active="true"
                     break
                 fi
@@ -661,7 +698,7 @@ function passwords_restartService() {
             service_is_active=""
 
             while [ "${restart_check_attempt}" -lt "${restart_check_retries}" ]; do
-                if eval "/etc/rc.d/init.d/${1} status ${debug}"; then
+                if passwords_isServiceActive "${1}" rcd; then
                     service_is_active="true"
                     break
                 fi

--- a/passwords_tool/passwordsFunctions.sh
+++ b/passwords_tool/passwordsFunctions.sh
@@ -542,7 +542,37 @@ function passwords_restartService() {
             fi
             exit 1;
         else
-            common_logger -d "${1} started."
+            # systemctl restart can return success immediately even if the
+            # service later fails to initialize (e.g. under resource
+            # pressure). Poll is-active for a short window to catch that
+            # before moving on, instead of only checking the restart call
+            # itself.
+            restart_check_retries=12
+            restart_check_delay=5
+            restart_check_attempt=0
+            service_is_active=""
+
+            while [ "${restart_check_attempt}" -lt "${restart_check_retries}" ]; do
+                if systemctl is-active --quiet "${1}.service"; then
+                    service_is_active="true"
+                    break
+                fi
+                restart_check_attempt=$((restart_check_attempt+1))
+                sleep "${restart_check_delay}"
+            done
+
+            if [ -z "${service_is_active}" ]; then
+                common_logger -e "${1} restarted but did not stay active (checked for $((restart_check_retries * restart_check_delay))s). It may have failed to initialize, for example due to insufficient resources."
+                if [ -n "$(command -v journalctl)" ]; then
+                    eval "journalctl -u ${1} >> ${logfile}"
+                fi
+                if [[ $(type -t installCommon_rollBack) == "function" ]]; then
+                    installCommon_rollBack
+                fi
+                exit 1;
+            else
+                common_logger -d "${1} started."
+            fi
         fi
     elif ps -p 1 -o comm= | grep "init"; then
         eval "/etc/init.d/${1} restart ${debug}"


### PR DESCRIPTION
Fixes wazuh/external-devel-requests#6840 — verifies wazuh-manager stays active after restart and retries the API user lookup before reporting a false "User wazuh is not registered in Wazuh API" error.